### PR TITLE
Fix 500 on credit card movement when default wallet is nil

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-- Fixed 500 on credit card movement when default wallet is nil
+- Fixed 500 on credit card movement when default wallet is nil [PR#188](https://github.com/silvioubaldino/personal-finance/pull/188)
 - Created coupon entity [PR#187](https://github.com/silvioubaldino/personal-finance/pull/187)
 - Created subscription entity [PR#186](https://github.com/silvioubaldino/personal-finance/pull/186)
 - Created user entity [PR#185](https://github.com/silvioubaldino/personal-finance/pull/185)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- Fixed 500 on credit card movement when default wallet is nil
 - Created coupon entity [PR#187](https://github.com/silvioubaldino/personal-finance/pull/187)
 - Created subscription entity [PR#186](https://github.com/silvioubaldino/personal-finance/pull/186)
 - Created user entity [PR#185](https://github.com/silvioubaldino/personal-finance/pull/185)

--- a/internal/infrastructure/api/errors_handler.go
+++ b/internal/infrastructure/api/errors_handler.go
@@ -52,7 +52,8 @@ func toAPIError(err error) errorResponse {
 		domain.Is(err, usecase.ErrRevenueCatWebhook):
 		return newErrorResponse(http.StatusBadRequest, "Invalid data provided")
 
-	case domain.Is(err, usecase.ErrInvalidFrequencyType):
+	case domain.Is(err, usecase.ErrInvalidFrequencyType),
+		domain.Is(err, usecase.ErrCreditCardNoDefaultWallet):
 		return newErrorResponse(http.StatusBadRequest, err.Error())
 
 	case domain.Is(err, domain.ErrUnauthorized),

--- a/internal/usecase/creditcard_usecase.go
+++ b/internal/usecase/creditcard_usecase.go
@@ -58,6 +58,10 @@ func (uc CreditCard) validateCreditCard(creditCard domain.CreditCard) error {
 		}
 	}
 
+	if creditCard.DefaultWalletID == nil {
+		return ErrCreditCardNoDefaultWallet
+	}
+
 	return nil
 }
 

--- a/internal/usecase/movement_usecase.go
+++ b/internal/usecase/movement_usecase.go
@@ -142,6 +142,13 @@ func (u *Movement) getInvoice(ctx context.Context, tx *gorm.DB, movement *domain
 	}
 	movement.CreditCardInfo.InvoiceID = invoice.ID
 
+	if movement.WalletID == nil {
+		movement.WalletID = invoice.WalletID
+	}
+	if movement.WalletID == nil {
+		return fmt.Errorf("error creating movement: %w", ErrCreditCardNoDefaultWallet)
+	}
+
 	movement.IsPaid = false
 
 	newAmount := invoice.Amount + movement.Amount

--- a/internal/usecase/usecase_errors.go
+++ b/internal/usecase/usecase_errors.go
@@ -17,6 +17,7 @@ var (
 	ErrInvalidDueDay                 = errors.New("due day must be between 1 and 31")
 	ErrInvalidCreditLimit            = errors.New("credit limit must be positive")
 	ErrInvalidColor                  = errors.New("invalid color format")
+	ErrCreditCardNoDefaultWallet     = errors.New("credit card must have a default wallet")
 	ErrCreditCardPay                 = errors.New("credit card should`n be paid")
 	ErrUnsupportedMovementTypeV2     = errors.New("unsupported movement type for V2 endpoint")
 	ErrInvalidPaymentAmount          = errors.New("payment amount must be between invoice amount and zero")


### PR DESCRIPTION
- Require DefaultWalletID on credit card creation to prevent the issue at the source
- In getInvoice, fall back to invoice.WalletID when movement.WalletID is nil; return a clear 400 error instead of hitting the DB NOT NULL constraint
- Map ErrCreditCardNoDefaultWallet to HTTP 400 in the error handler