### PR TITLE
feat(subscription): migrate Mercado Pago to associated-plan checkout

### DIFF
--- a/db/migrations/025_mp_plan_and_coupon_target.down.sql
+++ b/db/migrations/025_mp_plan_and_coupon_target.down.sql
@@ -1,0 +1,6 @@
+ALTER TABLE coupons DROP COLUMN IF EXISTS target_plan_id;
+
+DROP INDEX IF EXISTS idx_subscription_plans_mp_preapproval_plan_id;
+
+ALTER TABLE subscription_plans DROP COLUMN IF EXISTS is_public;
+ALTER TABLE subscription_plans DROP COLUMN IF EXISTS mp_preapproval_plan_id;

--- a/db/migrations/025_mp_plan_and_coupon_target.up.sql
+++ b/db/migrations/025_mp_plan_and_coupon_target.up.sql
@@ -1,0 +1,10 @@
+ALTER TABLE subscription_plans
+    ADD COLUMN IF NOT EXISTS mp_preapproval_plan_id VARCHAR,
+    ADD COLUMN IF NOT EXISTS is_public BOOLEAN NOT NULL DEFAULT true;
+
+CREATE UNIQUE INDEX IF NOT EXISTS idx_subscription_plans_mp_preapproval_plan_id
+    ON subscription_plans (mp_preapproval_plan_id)
+    WHERE mp_preapproval_plan_id IS NOT NULL;
+
+ALTER TABLE coupons
+    ADD COLUMN IF NOT EXISTS target_plan_id VARCHAR;

--- a/docs/swagger.yaml
+++ b/docs/swagger.yaml
@@ -5,7 +5,7 @@ info:
     API de finanças pessoais com suporte a movimentações, cartões de crédito, faturas, carteiras, categorias, estimativas e extrato bancário.
 
     ## Autenticação
-    Todos os endpoints (exceto `/ping`, `/subscription/plan`, `/subscription/return` e webhooks públicos) requerem um Firebase ID Token no header `user_token`.
+    Todos os endpoints (exceto `/ping`, `/subscription/plan` e webhooks públicos) requerem um Firebase ID Token no header `user_token`.
     Endpoints sob `/jobs` requerem uma API key interna no header `x-api-key`.
 
     ## Versionamento
@@ -120,20 +120,6 @@ paths:
                   $ref: "#/components/schemas/SubscriptionPlanOutput"
         "500":
           $ref: "#/components/responses/InternalServerError"
-
-  /subscription/return:
-    get:
-      tags: [Subscription Plans]
-      summary: Redirect pós-checkout (MercadoPago)
-      description: |
-        Endpoint público usado pelo MercadoPago para redirecionar o usuário após o checkout.
-        Redireciona para o deeplink configurado em `MERCADOPAGO_APP_DEEPLINK`.
-      security: []
-      responses:
-        "302":
-          description: Redirecionamento para o app
-        "404":
-          description: Deeplink não configurado
 
   # ─────────────────────────────────────────
   # WEBHOOKS (public)
@@ -3455,7 +3441,11 @@ components:
           items:
             type: string
           example: ["plan_pro", "plan_premium"]
-          description: IDs dos planos elegíveis. Array vazio = aplica a todos os planos.
+          description: IDs dos planos base elegíveis. Array vazio = aplica a todos os planos.
+        target_plan_id:
+          type: string
+          description: ID do plano promocional (não público) para onde o checkout redireciona quando o cupom é aplicado.
+          example: "plan_pro_promo50"
         is_active:
           type: boolean
           default: false
@@ -3493,6 +3483,10 @@ components:
           items:
             type: string
           example: ["plan_pro"]
+        target_plan_id:
+          type: string
+          description: ID do plano promocional (não público) para onde o checkout redireciona.
+          example: "plan_pro_promo50"
         is_active:
           type: boolean
 
@@ -3634,13 +3628,9 @@ components:
           type: string
           description: ID do plano de assinatura
           example: "plan_pro"
-        back_url:
-          type: string
-          description: URL de retorno após o checkout (deep link ou URL web)
-          example: "myapp://subscription/result"
         coupon_code:
           type: string
-          description: Código de cupom para desconto
+          description: Código de cupom para desconto (redireciona para o plano promocional vinculado)
           example: "BLACK20"
 
     # ── ADMIN ────────────────────────────────
@@ -3689,7 +3679,7 @@ components:
 
     CreatePlanRequest:
       type: object
-      required: [id, name, price, frequency, frequency_type]
+      required: [id, name, price, frequency, frequency_type, reason, back_url]
       properties:
         id:
           type: string
@@ -3715,6 +3705,18 @@ components:
         is_active:
           type: boolean
           default: false
+        is_promo:
+          type: boolean
+          default: false
+          description: Marca um plano promocional não público (alvo de cupom). Planos base/storefront omitem o campo.
+        reason:
+          type: string
+          description: Descrição que aparece no checkout/notificações do Mercado Pago (config do plano, criada no preapproval_plan).
+          example: "Personal Finance Pro"
+        back_url:
+          type: string
+          description: URL web de retorno pós-checkout, definida no plano do Mercado Pago.
+          example: "https://app.suaurl.com/assinatura/retorno"
 
     SubscriptionsSummaryResponse:
       type: object

--- a/internal/bootstrap/admin/setup.go
+++ b/internal/bootstrap/admin/setup.go
@@ -14,9 +14,10 @@ func Setup(r *gin.Engine, registry *registry.Registry) {
 	authClient := authenticator.AuthClient()
 
 	firebaseGateway := gateway.NewFirebaseGateway(authClient)
+	mpGateway := gateway.NewMercadoPagoGateway()
 	adminUseCase := usecase.NewAdmin(firebaseGateway)
 	subscriptionUseCase := usecase.NewSubscription(
-		nil,
+		mpGateway,
 		nil,
 		registry.GetSubscriptionPlanRepository(),
 		registry.GetSubscriptionRepository(),

--- a/internal/bootstrap/subscription/setup.go
+++ b/internal/bootstrap/subscription/setup.go
@@ -21,5 +21,4 @@ func Setup(r *gin.Engine, registry *registry.Registry, couponUseCase usecase.Cou
 	subscriptionUseCase := usecase.NewSubscription(mpGateway, firebaseGateway, planRepo, subRepo, couponUseCase)
 
 	api.NewSubscriptionHandlers(r, subscriptionUseCase, authenticator.Authenticate())
-	api.RegisterSubscriptionReturnRoute(r)
 }

--- a/internal/domain/coupon.go
+++ b/internal/domain/coupon.go
@@ -33,9 +33,13 @@ type Coupon struct {
 	MaxRedemptions    *int
 	RedemptionCount   int
 	ApplicablePlanIDs []string
-	IsActive          bool
-	CreatedAt         time.Time
-	UpdatedAt         time.Time
+	// TargetPlanID is the (non-public) promotional subscription plan the checkout
+	// redirects to when this coupon is applied. The promo plan carries the
+	// discounted price and its own Mercado Pago preapproval_plan.
+	TargetPlanID string
+	IsActive     bool
+	CreatedAt    time.Time
+	UpdatedAt    time.Time
 }
 
 type CouponRedemption struct {
@@ -60,4 +64,5 @@ var (
 	ErrCouponPlanNotApplicable = errors.New("coupon does not apply to this plan")
 	ErrCouponInvalidPrice      = errors.New("coupon would result in non-positive price")
 	ErrCouponRedemptionMissing = errors.New("coupon redemption not found")
+	ErrCouponTargetPlanMissing = errors.New("coupon target plan is not configured")
 )

--- a/internal/domain/coupon.go
+++ b/internal/domain/coupon.go
@@ -33,13 +33,10 @@ type Coupon struct {
 	MaxRedemptions    *int
 	RedemptionCount   int
 	ApplicablePlanIDs []string
-	// TargetPlanID is the (non-public) promotional subscription plan the checkout
-	// redirects to when this coupon is applied. The promo plan carries the
-	// discounted price and its own Mercado Pago preapproval_plan.
-	TargetPlanID string
-	IsActive     bool
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	TargetPlanID  	  string
+	IsActive     	  bool
+	CreatedAt    	  time.Time
+	UpdatedAt    	  time.Time
 }
 
 type CouponRedemption struct {

--- a/internal/domain/subscription_plan.go
+++ b/internal/domain/subscription_plan.go
@@ -1,11 +1,13 @@
 package domain
 
 type SubscriptionPlan struct {
-	ID            string  `json:"id"`
-	Name          string  `json:"name"`
-	Price         float64 `json:"price"`
-	Currency      string  `json:"currency"`
-	Frequency     int     `json:"frequency"`
-	FrequencyType string  `json:"frequency_type"`
-	IsActive      bool    `json:"is_active"`
+	ID                  string  `json:"id"`
+	Name                string  `json:"name"`
+	Price               float64 `json:"price"`
+	Currency            string  `json:"currency"`
+	Frequency           int     `json:"frequency"`
+	FrequencyType       string  `json:"frequency_type"`
+	IsActive            bool    `json:"is_active"`
+	IsPublic            bool    `json:"is_public"`
+	MPPreapprovalPlanID string  `json:"mp_preapproval_plan_id,omitempty"`
 }

--- a/internal/infrastructure/api/admin_api.go
+++ b/internal/infrastructure/api/admin_api.go
@@ -34,7 +34,7 @@ type (
 	}
 
 	SubscriptionPlanAdminUseCase interface {
-		CreatePlan(ctx context.Context, plan domain.SubscriptionPlan) error
+		CreatePlan(ctx context.Context, plan domain.SubscriptionPlan, reason, backURL string) error
 	}
 
 	SubscriptionPlanAdminHandler struct {
@@ -61,6 +61,12 @@ type (
 		Frequency     int     `json:"frequency" binding:"required,gt=0"`
 		FrequencyType string  `json:"frequency_type" binding:"required"`
 		IsActive      bool    `json:"is_active"`
+		// IsPromo marks a non-public promotional plan (coupon target). Base/storefront
+		// plans omit it and are public. Reason and BackURL are the Mercado Pago plan
+		// config (formerly env vars) sent when creating the preapproval_plan.
+		IsPromo bool   `json:"is_promo"`
+		Reason  string `json:"reason" binding:"required"`
+		BackURL string `json:"back_url" binding:"required"`
 	}
 )
 
@@ -116,9 +122,10 @@ func (h SubscriptionPlanAdminHandler) CreatePlan() gin.HandlerFunc {
 			Frequency:     req.Frequency,
 			FrequencyType: req.FrequencyType,
 			IsActive:      req.IsActive,
+			IsPublic:      !req.IsPromo,
 		}
 
-		if err := h.usecase.CreatePlan(ctx, plan); err != nil {
+		if err := h.usecase.CreatePlan(ctx, plan, req.Reason, req.BackURL); err != nil {
 			HandleErr(c, ctx, err)
 			return
 		}

--- a/internal/infrastructure/api/admin_api.go
+++ b/internal/infrastructure/api/admin_api.go
@@ -61,12 +61,9 @@ type (
 		Frequency     int     `json:"frequency" binding:"required,gt=0"`
 		FrequencyType string  `json:"frequency_type" binding:"required"`
 		IsActive      bool    `json:"is_active"`
-		// IsPromo marks a non-public promotional plan (coupon target). Base/storefront
-		// plans omit it and are public. Reason and BackURL are the Mercado Pago plan
-		// config (formerly env vars) sent when creating the preapproval_plan.
-		IsPromo bool   `json:"is_promo"`
-		Reason  string `json:"reason" binding:"required"`
-		BackURL string `json:"back_url" binding:"required"`
+		IsPromo       bool    `json:"is_promo"`
+		Reason        string  `json:"reason" binding:"required"`
+		BackURL       string  `json:"back_url" binding:"required"`
 	}
 )
 

--- a/internal/infrastructure/api/coupon_admin_api.go
+++ b/internal/infrastructure/api/coupon_admin_api.go
@@ -35,6 +35,7 @@ type (
 		ValidUntil        time.Time `json:"valid_until" binding:"required"`
 		MaxRedemptions    *int      `json:"max_redemptions"`
 		ApplicablePlanIDs []string  `json:"applicable_plan_ids"`
+		TargetPlanID      string    `json:"target_plan_id"`
 		IsActive          bool      `json:"is_active"`
 	}
 
@@ -46,6 +47,7 @@ type (
 		ValidUntil        *time.Time `json:"valid_until"`
 		MaxRedemptions    *int       `json:"max_redemptions"`
 		ApplicablePlanIDs []string   `json:"applicable_plan_ids"`
+		TargetPlanID      *string    `json:"target_plan_id"`
 		IsActive          *bool      `json:"is_active"`
 	}
 )
@@ -82,6 +84,7 @@ func (h CouponAdminHandler) Create() gin.HandlerFunc {
 			ValidUntil:        req.ValidUntil,
 			MaxRedemptions:    req.MaxRedemptions,
 			ApplicablePlanIDs: req.ApplicablePlanIDs,
+			TargetPlanID:      req.TargetPlanID,
 			IsActive:          req.IsActive,
 		}
 
@@ -122,6 +125,7 @@ func (h CouponAdminHandler) Update() gin.HandlerFunc {
 			ValidUntil:        req.ValidUntil,
 			MaxRedemptions:    req.MaxRedemptions,
 			ApplicablePlanIDs: req.ApplicablePlanIDs,
+			TargetPlanID:      req.TargetPlanID,
 			IsActive:          req.IsActive,
 		}
 

--- a/internal/infrastructure/api/subscription_api.go
+++ b/internal/infrastructure/api/subscription_api.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"io"
 	"net/http"
-	"os"
 
 	"personal-finance/internal/domain"
 
@@ -13,7 +12,7 @@ import (
 
 type (
 	SubscriptionUseCase interface {
-		CreateCheckout(ctx context.Context, planID, backURL, couponCode string) (string, error)
+		CreateCheckout(ctx context.Context, planID, couponCode string) (string, error)
 		CancelSubscription(ctx context.Context) error
 		HandleWebhook(ctx context.Context, xSignature, xRequestId string, body []byte) error
 		HandleRevenueCatWebhook(ctx context.Context, authHeader string, body []byte) error
@@ -43,19 +42,6 @@ func NewSubscriptionHandlers(r *gin.Engine, srv SubscriptionUseCase, auth gin.Ha
 	webhooksGroup.POST("/revenuecat", handler.HandleRevenueCatWebhook())
 }
 
-// RegisterSubscriptionReturnRoute registers the public redirect endpoint that MP uses after checkout.
-// Must be called before any global auth middleware is added to the engine.
-func RegisterSubscriptionReturnRoute(r *gin.Engine) {
-	deeplink := os.Getenv("MERCADOPAGO_APP_DEEPLINK")
-	r.GET("/subscription/return", func(c *gin.Context) {
-		if deeplink == "" {
-			c.Status(http.StatusNotFound)
-			return
-		}
-		c.Redirect(http.StatusFound, deeplink)
-	})
-}
-
 func (h SubscriptionHandler) GetPlan() gin.HandlerFunc {
 	return func(c *gin.Context) {
 		ctx := c.Request.Context()
@@ -70,7 +56,6 @@ func (h SubscriptionHandler) GetPlan() gin.HandlerFunc {
 
 type createCheckoutRequest struct {
 	PlanID     string `json:"plan_id" binding:"required"`
-	BackURL    string `json:"back_url"`
 	CouponCode string `json:"coupon_code"`
 }
 
@@ -84,7 +69,7 @@ func (h SubscriptionHandler) CreateCheckout() gin.HandlerFunc {
 			return
 		}
 
-		resp, err := h.usecase.CreateCheckout(ctx, req.PlanID, req.BackURL, req.CouponCode)
+		resp, err := h.usecase.CreateCheckout(ctx, req.PlanID, req.CouponCode)
 		if err != nil {
 			HandleErr(c, ctx, err)
 			return

--- a/internal/infrastructure/gateway/mercadopago_gateway.go
+++ b/internal/infrastructure/gateway/mercadopago_gateway.go
@@ -30,9 +30,6 @@ func NewMercadoPagoGateway() *MercadoPagoGateway {
 	}
 }
 
-// CreatePlan creates a preapproval_plan (subscription template) in Mercado Pago and
-// returns the plan id and its init_point. Plan config (reason, back_url, recurrence,
-// amount, currency) comes from our DB — there are no plan-config env vars anymore.
 func (g *MercadoPagoGateway) CreatePlan(ctx context.Context, plan SubscriptionPlanConfig, reason, backURL string) (string, string, error) {
 	req := MPCreatePlanRequest{
 		Reason:  reason,
@@ -76,10 +73,6 @@ func (g *MercadoPagoGateway) CreatePlan(ctx context.Context, plan SubscriptionPl
 	return res.ID, res.InitPoint, nil
 }
 
-// BuildPlanCheckoutURL builds the subscription checkout URL for a preapproval_plan.
-// The subscriber logs into their own Mercado Pago account on this page, so we never
-// send a payer email and there is no email-mismatch rejection. external_reference lets
-// the webhook tie the resulting subscription back to our user.
 func (g *MercadoPagoGateway) BuildPlanCheckoutURL(planID, externalReference string) string {
 	checkoutURL := fmt.Sprintf("%s/subscriptions/checkout?preapproval_plan_id=%s", g.checkoutBase, url.QueryEscape(planID))
 	if externalReference != "" {

--- a/internal/infrastructure/gateway/mercadopago_gateway.go
+++ b/internal/infrastructure/gateway/mercadopago_gateway.go
@@ -4,69 +4,60 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"net/http"
+	"net/url"
 	"os"
-	"strings"
 	"time"
 )
 
-var ErrCrossCountry = errors.New("cannot operate between different countries")
-
 const (
-	_createSubscriptionPath = "/preapproval"
+	_createPlanPath = "/preapproval_plan"
 
-	envMPBaseURL  = "MERCADOPAGO_BASE_URL"
-	envMPReason   = "MERCADOPAGO_REASON"
-	envMPBackURL  = "MERCADOPAGO_BACK_URL"
-	envMPCurrency = "MERCADOPAGO_CURRENCY"
+	envMPBaseURL      = "MERCADOPAGO_BASE_URL"
+	envMPCheckoutBase = "MERCADOPAGO_CHECKOUT_BASE"
 
-	defaultMPBaseURL  = "https://api.mercadopago.com"
-	defaultMPReason   = "Personal Finance Subscription"
-	defaultMPBackURL  = "https://personal-finance-frontend-v2.vercel.app/"
-	defaultMPCurrency = "BRL"
+	defaultMPBaseURL      = "https://api.mercadopago.com"
+	defaultMPCheckoutBase = "https://www.mercadopago.com.br"
 )
 
 func NewMercadoPagoGateway() *MercadoPagoGateway {
-	mpBaseURL := getEnv(envMPBaseURL, defaultMPBaseURL)
-	mpReason := getEnv(envMPReason, defaultMPReason)
-	mpBackURL := getEnv(envMPBackURL, defaultMPBackURL)
-	mpCurrency := getEnv(envMPCurrency, defaultMPCurrency)
-
 	return &MercadoPagoGateway{
-		httpClient:  &http.Client{Timeout: 10 * time.Second},
-		accessToken: os.Getenv("MERCADOPAGO_ACCESS_TOKEN"),
-		baseURL:     mpBaseURL,
-		reason:      mpReason,
-		backURL:     mpBackURL,
-		currency:    mpCurrency,
+		httpClient:   &http.Client{Timeout: 10 * time.Second},
+		accessToken:  os.Getenv("MERCADOPAGO_ACCESS_TOKEN"),
+		baseURL:      getEnv(envMPBaseURL, defaultMPBaseURL),
+		checkoutBase: getEnv(envMPCheckoutBase, defaultMPCheckoutBase),
 	}
 }
 
-type MPCreateSubscriptionResponse struct {
-	ID               string `json:"id"`
-	InitPoint        string `json:"init_point"`
-	SandboxInitPoint string `json:"sandbox_init_point"`
-	Status           string `json:"status"`
-}
-
-func (g *MercadoPagoGateway) CreateSubscriptionURL(ctx context.Context, payerEmail, externalReference, backURL string, plan SubscriptionPlanConfig) (string, error) {
-	req := g.buildMPRequest(payerEmail, externalReference, backURL, plan)
+// CreatePlan creates a preapproval_plan (subscription template) in Mercado Pago and
+// returns the plan id and its init_point. Plan config (reason, back_url, recurrence,
+// amount, currency) comes from our DB — there are no plan-config env vars anymore.
+func (g *MercadoPagoGateway) CreatePlan(ctx context.Context, plan SubscriptionPlanConfig, reason, backURL string) (string, string, error) {
+	req := MPCreatePlanRequest{
+		Reason:  reason,
+		BackURL: backURL,
+		AutoRecurring: MPAutoRecurring{
+			Frequency:         plan.Frequency,
+			FrequencyType:     plan.FrequencyType,
+			TransactionAmount: plan.Price,
+			CurrencyID:        plan.Currency,
+		},
+	}
 
 	body, err := json.Marshal(req)
 	if err != nil {
-		return "", fmt.Errorf("error marshaling request: %w", err)
+		return "", "", fmt.Errorf("error marshaling request: %w", err)
 	}
 
-	httpReq, err := g.buildHTTPCreateRequest(ctx, _createSubscriptionPath, body)
+	httpReq, err := g.buildHTTPCreateRequest(ctx, _createPlanPath, body)
 	if err != nil {
-		return "", fmt.Errorf("error creating request: %w", err)
+		return "", "", fmt.Errorf("error creating request: %w", err)
 	}
 
 	resp, err := g.httpClient.Do(httpReq)
 	if err != nil {
-		return "", fmt.Errorf("error sending request: %w", err)
+		return "", "", fmt.Errorf("error sending request: %w", err)
 	}
 	defer resp.Body.Close()
 
@@ -74,18 +65,27 @@ func (g *MercadoPagoGateway) CreateSubscriptionURL(ctx context.Context, payerEma
 		var errorResponse interface{}
 		_ = json.NewDecoder(resp.Body).Decode(&errorResponse)
 		errJSON, _ := json.Marshal(errorResponse)
-		if strings.Contains(string(errJSON), "Cannot operate between different countries") {
-			return "", ErrCrossCountry
-		}
-		return "", fmt.Errorf("mercado pago api returned status: %d error: %s", resp.StatusCode, string(errJSON))
+		return "", "", fmt.Errorf("mercado pago api returned status: %d error: %s", resp.StatusCode, string(errJSON))
 	}
 
-	var res MPCreateSubscriptionResponse
+	var res MPCreatePlanResponse
 	if err := json.NewDecoder(resp.Body).Decode(&res); err != nil {
-		return "", fmt.Errorf("error decoding response: %w", err)
+		return "", "", fmt.Errorf("error decoding response: %w", err)
 	}
 
-	return res.InitPoint, nil
+	return res.ID, res.InitPoint, nil
+}
+
+// BuildPlanCheckoutURL builds the subscription checkout URL for a preapproval_plan.
+// The subscriber logs into their own Mercado Pago account on this page, so we never
+// send a payer email and there is no email-mismatch rejection. external_reference lets
+// the webhook tie the resulting subscription back to our user.
+func (g *MercadoPagoGateway) BuildPlanCheckoutURL(planID, externalReference string) string {
+	checkoutURL := fmt.Sprintf("%s/subscriptions/checkout?preapproval_plan_id=%s", g.checkoutBase, url.QueryEscape(planID))
+	if externalReference != "" {
+		checkoutURL += "&external_reference=" + url.QueryEscape(externalReference)
+	}
+	return checkoutURL
 }
 
 func (g *MercadoPagoGateway) buildHTTPCreateRequest(ctx context.Context, path string, body []byte) (*http.Request, error) {
@@ -101,9 +101,9 @@ func (g *MercadoPagoGateway) buildHTTPCreateRequest(ctx context.Context, path st
 }
 
 func (g *MercadoPagoGateway) GetSubscription(ctx context.Context, id string) (MPSubscription, error) {
-	url := fmt.Sprintf("%s/preapproval/%s", g.baseURL, id)
+	requestURL := fmt.Sprintf("%s/preapproval/%s", g.baseURL, id)
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, url, nil)
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodGet, requestURL, nil)
 	if err != nil {
 		return MPSubscription{}, fmt.Errorf("error creating request: %w", err)
 	}
@@ -132,7 +132,7 @@ func (g *MercadoPagoGateway) GetSubscription(ctx context.Context, id string) (MP
 }
 
 func (g *MercadoPagoGateway) CancelSubscription(ctx context.Context, id string) error {
-	url := fmt.Sprintf("%s/preapproval/%s", g.baseURL, id)
+	requestURL := fmt.Sprintf("%s/preapproval/%s", g.baseURL, id)
 
 	req := map[string]string{
 		"status": "cancelled",
@@ -143,7 +143,7 @@ func (g *MercadoPagoGateway) CancelSubscription(ctx context.Context, id string) 
 		return fmt.Errorf("error marshaling request: %w", err)
 	}
 
-	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, url, bytes.NewReader(body))
+	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPut, requestURL, bytes.NewReader(body))
 	if err != nil {
 		return fmt.Errorf("error creating request: %w", err)
 	}
@@ -172,32 +172,4 @@ func getEnv(key, defaultValue string) string {
 		return value
 	}
 	return defaultValue
-}
-
-func (g *MercadoPagoGateway) buildMPRequest(payerEmail, externalReference, backURL string, plan SubscriptionPlanConfig) MPCreateSubscriptionRequest {
-	startDate := time.Now().Add(1 * time.Hour).Format("2006-01-02T15:04:05.000-07:00")
-
-	resolvedBackURL := backURL
-	if resolvedBackURL == "" {
-		resolvedBackURL = g.backURL
-	}
-
-	currency := plan.Currency
-	if currency == "" {
-		currency = g.currency
-	}
-
-	return MPCreateSubscriptionRequest{
-		PayerEmail:        payerEmail,
-		Reason:            g.reason,
-		ExternalReference: externalReference,
-		BackURL:           resolvedBackURL,
-		AutoRecurring: MPAutoRecurring{
-			Frequency:         plan.Frequency,
-			FrequencyType:     plan.FrequencyType,
-			TransactionAmount: plan.Price,
-			CurrencyID:        currency,
-			StartDate:         startDate,
-		},
-	}
 }

--- a/internal/infrastructure/gateway/mp_model.go
+++ b/internal/infrastructure/gateway/mp_model.go
@@ -12,12 +12,10 @@ type MPSubscription struct {
 }
 
 type MercadoPagoGateway struct {
-	httpClient  *http.Client
-	accessToken string
-	baseURL     string
-	reason      string
-	currency    string
-	backURL     string
+	httpClient   *http.Client
+	accessToken  string
+	baseURL      string
+	checkoutBase string
 }
 
 type SubscriptionPlanConfig struct {
@@ -35,11 +33,17 @@ type MPAutoRecurring struct {
 	StartDate         string  `json:"start_date,omitempty"`
 }
 
-type MPCreateSubscriptionRequest struct {
-	PayerEmail        string          `json:"payer_email"`
+// MPCreatePlanRequest is the body for POST /preapproval_plan. It intentionally has
+// no payer_email: the subscriber's account (and email) is captured at the plan's
+// checkout, so there is no email-mismatch rejection.
+type MPCreatePlanRequest struct {
 	Reason            string          `json:"reason"`
-	ExternalReference string          `json:"external_reference"`
 	BackURL           string          `json:"back_url"`
+	ExternalReference string          `json:"external_reference,omitempty"`
 	AutoRecurring     MPAutoRecurring `json:"auto_recurring"`
-	Status            string          `json:"status,omitempty"`
+}
+
+type MPCreatePlanResponse struct {
+	ID        string `json:"id"`
+	InitPoint string `json:"init_point"`
 }

--- a/internal/infrastructure/repository/coupon_repository.go
+++ b/internal/infrastructure/repository/coupon_repository.go
@@ -49,6 +49,7 @@ func (r *CouponRepository) Update(ctx context.Context, coupon domain.Coupon) err
 			"valid_until":         row.ValidUntil,
 			"max_redemptions":     row.MaxRedemptions,
 			"applicable_plan_ids": row.ApplicablePlanIDs,
+			"target_plan_id":      row.TargetPlanID,
 			"is_active":           row.IsActive,
 			"updated_at":          row.UpdatedAt,
 		})

--- a/internal/infrastructure/repository/model.go
+++ b/internal/infrastructure/repository/model.go
@@ -40,25 +40,25 @@ func (MovementDB) TableName() string {
 
 func (m MovementDB) ToDomain() domain.Movement {
 	movement := domain.Movement{
-		ID:            m.ID,
-		Description:   m.Description,
-		Amount:        m.Amount,
-		Date:          m.Date,
-		UserID:        m.UserID,
-		IsPaid:        m.IsPaid,
-		IsRecurrent:   m.RecurrentID != nil,
-		RecurrentID:   m.RecurrentID,
-		PairID:        m.PairID,
-		WalletID:      m.WalletID,
-		Wallet:        m.Wallet.ToDomain(),
-		TypePayment:   domain.TypePayment(m.TypePayment),
-		CategoryID:    m.CategoryID,
-		Category:      m.Category.ToDomain(),
-		SubCategoryID: m.SubCategoryID,
-		SubCategory:   m.SubCategory.ToDomain(),
+		ID:              m.ID,
+		Description:     m.Description,
+		Amount:          m.Amount,
+		Date:            m.Date,
+		UserID:          m.UserID,
+		IsPaid:          m.IsPaid,
+		IsRecurrent:     m.RecurrentID != nil,
+		RecurrentID:     m.RecurrentID,
+		PairID:          m.PairID,
+		WalletID:        m.WalletID,
+		Wallet:          m.Wallet.ToDomain(),
+		TypePayment:     domain.TypePayment(m.TypePayment),
+		CategoryID:      m.CategoryID,
+		Category:        m.Category.ToDomain(),
+		SubCategoryID:   m.SubCategoryID,
+		SubCategory:     m.SubCategory.ToDomain(),
 		IdempotencyHash: m.IdempotencyHash,
-		DateCreate:    m.DateCreate,
-		DateUpdate:    m.DateUpdate,
+		DateCreate:      m.DateCreate,
+		DateUpdate:      m.DateUpdate,
 	}
 
 	if m.InvoiceID != nil || m.InstallmentGroupID != nil {
@@ -81,17 +81,17 @@ func (m MovementDB) ToDomain() domain.Movement {
 
 func FromMovementDomain(d domain.Movement) MovementDB {
 	movementDB := MovementDB{
-		ID:            d.ID,
-		Description:   d.Description,
-		Amount:        d.Amount,
-		Date:          d.Date,
-		UserID:        d.UserID,
-		IsPaid:        d.IsPaid,
-		RecurrentID:   d.RecurrentID,
-		PairID:        d.PairID,
-		WalletID:      d.WalletID,
-		TypePayment:   string(d.TypePayment),
-		CategoryID:    d.CategoryID,
+		ID:              d.ID,
+		Description:     d.Description,
+		Amount:          d.Amount,
+		Date:            d.Date,
+		UserID:          d.UserID,
+		IsPaid:          d.IsPaid,
+		RecurrentID:     d.RecurrentID,
+		PairID:          d.PairID,
+		WalletID:        d.WalletID,
+		TypePayment:     string(d.TypePayment),
+		CategoryID:      d.CategoryID,
 		SubCategoryID:   d.SubCategoryID,
 		IdempotencyHash: d.IdempotencyHash,
 		DateCreate:      d.DateCreate,
@@ -109,14 +109,14 @@ func FromMovementDomain(d domain.Movement) MovementDB {
 }
 
 type CategoryDB struct {
-	ID            *uuid.UUID     `gorm:"primaryKey"`
-	Description   string         `gorm:"description,omitempty"`
-	UserID        string         `gorm:"user_id"`
-	Color         string         `gorm:"color"`
-	IsIncome      bool           `gorm:"is_income"`
+	ID            *uuid.UUID      `gorm:"primaryKey"`
+	Description   string          `gorm:"description,omitempty"`
+	UserID        string          `gorm:"user_id"`
+	Color         string          `gorm:"color"`
+	IsIncome      bool            `gorm:"is_income"`
 	SubCategories []SubCategoryDB `gorm:"foreignKey:CategoryID"`
-	DateCreate    time.Time      `gorm:"date_create"`
-	DateUpdate    time.Time      `gorm:"date_update"`
+	DateCreate    time.Time       `gorm:"date_create"`
+	DateUpdate    time.Time       `gorm:"date_update"`
 }
 
 func (CategoryDB) TableName() string {
@@ -493,17 +493,19 @@ func FromDeviceDomain(d domain.Device) UserDeviceDB {
 }
 
 type SubscriptionPlanDB struct {
-	ID              string  `gorm:"primaryKey"`
-	Name            string
-	Price           float64
-	Currency        string
-	Frequency       int
-	FrequencyType   string
-	IsActive        bool
-	AppleProductID  *string `gorm:"column:apple_product_id"`
-	GoogleProductID *string `gorm:"column:google_product_id"`
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
+	ID                  string `gorm:"primaryKey"`
+	Name                string
+	Price               float64
+	Currency            string
+	Frequency           int
+	FrequencyType       string
+	IsActive            bool
+	IsPublic            bool    `gorm:"column:is_public"`
+	MPPreapprovalPlanID *string `gorm:"column:mp_preapproval_plan_id"`
+	AppleProductID      *string `gorm:"column:apple_product_id"`
+	GoogleProductID     *string `gorm:"column:google_product_id"`
+	CreatedAt           time.Time
+	UpdatedAt           time.Time
 }
 
 func (SubscriptionPlanDB) TableName() string {
@@ -511,14 +513,20 @@ func (SubscriptionPlanDB) TableName() string {
 }
 
 func (p SubscriptionPlanDB) ToDomain() domain.SubscriptionPlan {
+	mpPlanID := ""
+	if p.MPPreapprovalPlanID != nil {
+		mpPlanID = *p.MPPreapprovalPlanID
+	}
 	return domain.SubscriptionPlan{
-		ID:            p.ID,
-		Name:          p.Name,
-		Price:         p.Price,
-		Currency:      p.Currency,
-		Frequency:     p.Frequency,
-		FrequencyType: p.FrequencyType,
-		IsActive:      p.IsActive,
+		ID:                  p.ID,
+		Name:                p.Name,
+		Price:               p.Price,
+		Currency:            p.Currency,
+		Frequency:           p.Frequency,
+		FrequencyType:       p.FrequencyType,
+		IsActive:            p.IsActive,
+		IsPublic:            p.IsPublic,
+		MPPreapprovalPlanID: mpPlanID,
 	}
 }
 
@@ -577,6 +585,7 @@ type CouponDB struct {
 	MaxRedemptions    *int      `gorm:"column:max_redemptions"`
 	RedemptionCount   int       `gorm:"column:redemption_count"`
 	ApplicablePlanIDs string    `gorm:"column:applicable_plan_ids"`
+	TargetPlanID      *string   `gorm:"column:target_plan_id"`
 	IsActive          bool      `gorm:"column:is_active"`
 	CreatedAt         time.Time `gorm:"column:created_at"`
 	UpdatedAt         time.Time `gorm:"column:updated_at"`
@@ -587,6 +596,10 @@ func (CouponDB) TableName() string {
 }
 
 func (c CouponDB) ToDomain() domain.Coupon {
+	targetPlanID := ""
+	if c.TargetPlanID != nil {
+		targetPlanID = *c.TargetPlanID
+	}
 	return domain.Coupon{
 		ID:                c.ID,
 		Code:              c.Code,
@@ -598,6 +611,7 @@ func (c CouponDB) ToDomain() domain.Coupon {
 		MaxRedemptions:    c.MaxRedemptions,
 		RedemptionCount:   c.RedemptionCount,
 		ApplicablePlanIDs: decodeStringSlice(c.ApplicablePlanIDs),
+		TargetPlanID:      targetPlanID,
 		IsActive:          c.IsActive,
 		CreatedAt:         c.CreatedAt,
 		UpdatedAt:         c.UpdatedAt,
@@ -605,6 +619,11 @@ func (c CouponDB) ToDomain() domain.Coupon {
 }
 
 func FromCouponDomain(d domain.Coupon) CouponDB {
+	var targetPlanID *string
+	if d.TargetPlanID != "" {
+		tp := d.TargetPlanID
+		targetPlanID = &tp
+	}
 	return CouponDB{
 		ID:                d.ID,
 		Code:              d.Code,
@@ -616,6 +635,7 @@ func FromCouponDomain(d domain.Coupon) CouponDB {
 		MaxRedemptions:    d.MaxRedemptions,
 		RedemptionCount:   d.RedemptionCount,
 		ApplicablePlanIDs: encodeStringSlice(d.ApplicablePlanIDs),
+		TargetPlanID:      targetPlanID,
 		IsActive:          d.IsActive,
 		CreatedAt:         d.CreatedAt,
 		UpdatedAt:         d.UpdatedAt,

--- a/internal/infrastructure/repository/subscription_plan_repository.go
+++ b/internal/infrastructure/repository/subscription_plan_repository.go
@@ -22,16 +22,23 @@ func NewSubscriptionPlanRepository(db *gorm.DB) *SubscriptionPlanRepository {
 }
 
 func (r *SubscriptionPlanRepository) Create(ctx context.Context, plan domain.SubscriptionPlan) error {
+	var mpPlanID *string
+	if plan.MPPreapprovalPlanID != "" {
+		id := plan.MPPreapprovalPlanID
+		mpPlanID = &id
+	}
 	row := SubscriptionPlanDB{
-		ID:            plan.ID,
-		Name:          plan.Name,
-		Price:         plan.Price,
-		Currency:      plan.Currency,
-		Frequency:     plan.Frequency,
-		FrequencyType: plan.FrequencyType,
-		IsActive:      plan.IsActive,
-		CreatedAt:     time.Now(),
-		UpdatedAt:     time.Now(),
+		ID:                  plan.ID,
+		Name:                plan.Name,
+		Price:               plan.Price,
+		Currency:            plan.Currency,
+		Frequency:           plan.Frequency,
+		FrequencyType:       plan.FrequencyType,
+		IsActive:            plan.IsActive,
+		IsPublic:            plan.IsPublic,
+		MPPreapprovalPlanID: mpPlanID,
+		CreatedAt:           time.Now(),
+		UpdatedAt:           time.Now(),
 	}
 	err := r.db.WithContext(ctx).Create(&row).Error
 	if err != nil {
@@ -40,9 +47,11 @@ func (r *SubscriptionPlanRepository) Create(ctx context.Context, plan domain.Sub
 	return nil
 }
 
+// FindActive returns only public plans (the storefront). Promotional plans
+// (is_public = false) are resolved by id via FindActiveByID, not listed here.
 func (r *SubscriptionPlanRepository) FindActive(ctx context.Context) ([]domain.SubscriptionPlan, error) {
 	var rows []SubscriptionPlanDB
-	err := r.db.WithContext(ctx).Where("is_active = true").Order("created_at asc").Find(&rows).Error
+	err := r.db.WithContext(ctx).Where("is_active = true AND is_public = true").Order("created_at asc").Find(&rows).Error
 	if err != nil {
 		return nil, fmt.Errorf("error listing active plans: %w: %s", ErrDatabaseError, err.Error())
 	}
@@ -51,6 +60,24 @@ func (r *SubscriptionPlanRepository) FindActive(ctx context.Context) ([]domain.S
 		plans[i] = row.ToDomain()
 	}
 	return plans, nil
+}
+
+// UpdateMPPlanID stores the Mercado Pago preapproval_plan id created for a plan.
+func (r *SubscriptionPlanRepository) UpdateMPPlanID(ctx context.Context, planID, mpPlanID string) error {
+	res := r.db.WithContext(ctx).
+		Model(&SubscriptionPlanDB{}).
+		Where("id = ?", planID).
+		Updates(map[string]interface{}{
+			"mp_preapproval_plan_id": mpPlanID,
+			"updated_at":             time.Now(),
+		})
+	if res.Error != nil {
+		return fmt.Errorf("error updating mp plan id: %w: %s", ErrDatabaseError, res.Error.Error())
+	}
+	if res.RowsAffected == 0 {
+		return ErrSubscriptionPlanNotFound
+	}
+	return nil
 }
 
 func (r *SubscriptionPlanRepository) FindActiveByID(ctx context.Context, id string) (domain.SubscriptionPlan, error) {

--- a/internal/usecase/coupon_usecase.go
+++ b/internal/usecase/coupon_usecase.go
@@ -75,8 +75,6 @@ type CouponPreview struct {
 	Currency        string  `json:"currency,omitempty"`
 }
 
-// Preview validates a coupon for a given plan without creating any redemption.
-// Returns Valid=false with a human-readable reason on any failure.
 func (s *Coupon) Preview(ctx context.Context, userID, planID, code string) (CouponPreview, error) {
 	plan, err := s.planRepo.FindActiveByID(ctx, planID)
 	if err != nil {
@@ -108,10 +106,6 @@ func (s *Coupon) Preview(ctx context.Context, userID, planID, code string) (Coup
 	}, nil
 }
 
-// ApplyAtCheckout validates the coupon for the base plan, reserves a pending
-// redemption, and returns the promotional plan the checkout must redirect to. The
-// promo plan carries the discounted price and its own Mercado Pago preapproval_plan,
-// so we never compute an arbitrary per-user price.
 func (s *Coupon) ApplyAtCheckout(ctx context.Context, userID string, plan domain.SubscriptionPlan, code string) (targetPlan domain.SubscriptionPlan, redemptionID uuid.UUID, err error) {
 	coupon, err := s.couponRepo.FindActiveByCode(ctx, code)
 	if err != nil {
@@ -155,7 +149,6 @@ func (s *Coupon) ApplyAtCheckout(ctx context.Context, userID string, plan domain
 	return promoPlan, created.ID, nil
 }
 
-// resolveTargetPlan loads the (non-public) promotional plan a coupon points to.
 func (s *Coupon) resolveTargetPlan(ctx context.Context, coupon domain.Coupon) (domain.SubscriptionPlan, error) {
 	if coupon.TargetPlanID == "" {
 		return domain.SubscriptionPlan{}, domain.ErrCouponTargetPlanMissing

--- a/internal/usecase/coupon_usecase.go
+++ b/internal/usecase/coupon_usecase.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"math"
 	"time"
 
 	"personal-finance/internal/domain"
@@ -64,6 +63,7 @@ type CouponUpdateFields struct {
 	ValidUntil        *time.Time
 	MaxRedemptions    *int
 	ApplicablePlanIDs []string
+	TargetPlanID      *string
 	IsActive          *bool
 }
 
@@ -95,44 +95,48 @@ func (s *Coupon) Preview(ctx context.Context, userID, planID, code string) (Coup
 		return CouponPreview{Valid: false, Reason: reason, OriginalPrice: plan.Price, Currency: plan.Currency}, nil
 	}
 
-	locked, err := computeLockedPrice(coupon, plan.Price)
+	promoPlan, err := s.resolveTargetPlan(ctx, coupon)
 	if err != nil {
-		return CouponPreview{Valid: false, Reason: err.Error(), OriginalPrice: plan.Price, Currency: plan.Currency}, nil
+		return CouponPreview{Valid: false, Reason: "coupon target plan not configured", OriginalPrice: plan.Price, Currency: plan.Currency}, nil
 	}
 
 	return CouponPreview{
 		Valid:           true,
 		OriginalPrice:   plan.Price,
-		DiscountedPrice: locked,
+		DiscountedPrice: promoPlan.Price,
 		Currency:        plan.Currency,
 	}, nil
 }
 
-func (s *Coupon) ApplyAtCheckout(ctx context.Context, userID string, plan domain.SubscriptionPlan, code string) (lockedPrice float64, redemptionID uuid.UUID, err error) {
+// ApplyAtCheckout validates the coupon for the base plan, reserves a pending
+// redemption, and returns the promotional plan the checkout must redirect to. The
+// promo plan carries the discounted price and its own Mercado Pago preapproval_plan,
+// so we never compute an arbitrary per-user price.
+func (s *Coupon) ApplyAtCheckout(ctx context.Context, userID string, plan domain.SubscriptionPlan, code string) (targetPlan domain.SubscriptionPlan, redemptionID uuid.UUID, err error) {
 	coupon, err := s.couponRepo.FindActiveByCode(ctx, code)
 	if err != nil {
 		if errors.Is(err, domain.ErrCouponNotFound) {
-			return 0, uuid.Nil, domain.ErrCouponNotFound
+			return domain.SubscriptionPlan{}, uuid.Nil, domain.ErrCouponNotFound
 		}
-		return 0, uuid.Nil, err
+		return domain.SubscriptionPlan{}, uuid.Nil, err
 	}
 
 	if reason := s.validateCoupon(ctx, coupon, plan, userID); reason != "" {
-		return 0, uuid.Nil, mapValidationReason(reason)
+		return domain.SubscriptionPlan{}, uuid.Nil, mapValidationReason(reason)
 	}
 
-	locked, err := computeLockedPrice(coupon, plan.Price)
+	promoPlan, err := s.resolveTargetPlan(ctx, coupon)
 	if err != nil {
-		return 0, uuid.Nil, err
+		return domain.SubscriptionPlan{}, uuid.Nil, err
 	}
 
 	if existing, err := s.redemptionRepo.FindByUserCoupon(ctx, userID, coupon.ID); err == nil &&
 		existing.Status == domain.CouponRedemptionPending {
-		refreshed, err := s.redemptionRepo.RefreshPending(ctx, userID, coupon.ID, plan.Price, locked)
+		refreshed, err := s.redemptionRepo.RefreshPending(ctx, userID, coupon.ID, plan.Price, promoPlan.Price)
 		if err != nil {
-			return 0, uuid.Nil, err
+			return domain.SubscriptionPlan{}, uuid.Nil, err
 		}
-		return refreshed.LockedPrice, refreshed.ID, nil
+		return promoPlan, refreshed.ID, nil
 	}
 
 	created, err := s.redemptionRepo.Create(ctx, domain.CouponRedemption{
@@ -140,15 +144,27 @@ func (s *Coupon) ApplyAtCheckout(ctx context.Context, userID string, plan domain
 		CouponID:      coupon.ID,
 		PlanID:        plan.ID,
 		OriginalPrice: plan.Price,
-		LockedPrice:   locked,
+		LockedPrice:   promoPlan.Price,
 		Status:        domain.CouponRedemptionPending,
 		RedeemedAt:    time.Now(),
 	})
 	if err != nil {
-		return 0, uuid.Nil, err
+		return domain.SubscriptionPlan{}, uuid.Nil, err
 	}
 
-	return locked, created.ID, nil
+	return promoPlan, created.ID, nil
+}
+
+// resolveTargetPlan loads the (non-public) promotional plan a coupon points to.
+func (s *Coupon) resolveTargetPlan(ctx context.Context, coupon domain.Coupon) (domain.SubscriptionPlan, error) {
+	if coupon.TargetPlanID == "" {
+		return domain.SubscriptionPlan{}, domain.ErrCouponTargetPlanMissing
+	}
+	promo, err := s.planRepo.FindActiveByID(ctx, coupon.TargetPlanID)
+	if err != nil {
+		return domain.SubscriptionPlan{}, domain.ErrCouponTargetPlanMissing
+	}
+	return promo, nil
 }
 
 // Confirm marks the redemption as active and increments the coupon counter
@@ -220,6 +236,9 @@ func (s *Coupon) Update(ctx context.Context, id string, fields CouponUpdateField
 	if fields.ApplicablePlanIDs != nil {
 		current.ApplicablePlanIDs = fields.ApplicablePlanIDs
 	}
+	if fields.TargetPlanID != nil {
+		current.TargetPlanID = *fields.TargetPlanID
+	}
 	if fields.IsActive != nil {
 		current.IsActive = *fields.IsActive
 	}
@@ -281,7 +300,7 @@ func (s *Coupon) validateCoupon(ctx context.Context, coupon domain.Coupon, plan 
 	if len(coupon.ApplicablePlanIDs) > 0 && !contains(coupon.ApplicablePlanIDs, plan.ID) {
 		return "coupon does not apply to this plan"
 	}
-	
+
 	if existing, err := s.redemptionRepo.FindByUserCoupon(ctx, userID, coupon.ID); err == nil {
 		if existing.Status != domain.CouponRedemptionPending {
 			return "coupon already redeemed by this user"
@@ -305,24 +324,6 @@ func mapValidationReason(reason string) error {
 	default:
 		return fmt.Errorf("%w: %s", domain.ErrInvalidInput, reason)
 	}
-}
-
-func computeLockedPrice(coupon domain.Coupon, originalPrice float64) (float64, error) {
-	var locked float64
-	switch coupon.DiscountType {
-	case domain.CouponDiscountPercentage:
-		locked = originalPrice * (1 - coupon.DiscountValue/100)
-	case domain.CouponDiscountFixedAmount:
-		locked = originalPrice - coupon.DiscountValue
-	default:
-		return 0, domain.ErrCouponInvalidPrice
-	}
-	// Round to 2 decimals to avoid sending exotic numbers to MP.
-	locked = math.Round(locked*100) / 100
-	if locked <= 0 {
-		return 0, domain.ErrCouponInvalidPrice
-	}
-	return locked, nil
 }
 
 func contains(values []string, target string) bool {

--- a/internal/usecase/coupon_usecase_test.go
+++ b/internal/usecase/coupon_usecase_test.go
@@ -28,7 +28,8 @@ func newCouponUseCase(t *testing.T) (*Coupon, *repository.CouponRepository, *rep
 	couponRepo := repository.NewCouponRepository(db)
 	redRepo := repository.NewCouponRedemptionRepository(db)
 	planRepo := &fakePlanRepo{plans: map[string]domain.SubscriptionPlan{
-		"plus_monthly": {ID: "plus_monthly", Name: "Plus Mensal", Price: 10.00, Currency: "BRL", IsActive: true},
+		"plus_monthly":       {ID: "plus_monthly", Name: "Plus Mensal", Price: 10.00, Currency: "BRL", IsActive: true, IsPublic: true, MPPreapprovalPlanID: "mp-plan-monthly"},
+		"plus_monthly_promo": {ID: "plus_monthly_promo", Name: "Plus Mensal Promo", Price: 7.00, Currency: "BRL", IsActive: true, IsPublic: false, MPPreapprovalPlanID: "mp-plan-monthly-promo"},
 	}}
 	return NewCoupon(couponRepo, redRepo, planRepo, db), couponRepo, redRepo, planRepo
 }
@@ -61,6 +62,14 @@ func (f *fakePlanRepo) FindIDByStoreProduct(_ context.Context, _, _ string) (str
 	return "", nil
 }
 
+func (f *fakePlanRepo) UpdateMPPlanID(_ context.Context, planID, mpPlanID string) error {
+	if p, ok := f.plans[planID]; ok {
+		p.MPPreapprovalPlanID = mpPlanID
+		f.plans[planID] = p
+	}
+	return nil
+}
+
 func validCoupon(id, code string) domain.Coupon {
 	now := time.Now().UTC()
 	return domain.Coupon{
@@ -70,6 +79,7 @@ func validCoupon(id, code string) domain.Coupon {
 		DiscountValue: 30,
 		ValidFrom:     now.Add(-time.Hour),
 		ValidUntil:    now.Add(24 * time.Hour),
+		TargetPlanID:  "plus_monthly_promo",
 		IsActive:      true,
 	}
 }
@@ -85,14 +95,13 @@ func TestCoupon_Preview_HappyPath(t *testing.T) {
 	assert.Equal(t, 7.0, preview.DiscountedPrice)
 }
 
-func TestCoupon_Preview_RejectsZeroPrice(t *testing.T) {
+func TestCoupon_Preview_RejectsMissingTargetPlan(t *testing.T) {
 	uc, couponRepo, _, _ := newCouponUseCase(t)
-	c := validCoupon("c1", "FULL")
-	c.DiscountType = domain.CouponDiscountFixedAmount
-	c.DiscountValue = 20 // > plan price of 10
+	c := validCoupon("c1", "NOPLAN")
+	c.TargetPlanID = "does_not_exist"
 	assert.NoError(t, couponRepo.Create(context.Background(), c))
 
-	preview, err := uc.Preview(context.Background(), "user-1", "plus_monthly", "FULL")
+	preview, err := uc.Preview(context.Background(), "user-1", "plus_monthly", "NOPLAN")
 	assert.NoError(t, err)
 	assert.False(t, preview.Valid)
 }
@@ -125,9 +134,10 @@ func TestCoupon_ApplyAtCheckout_CreatesPendingRedemption(t *testing.T) {
 	assert.NoError(t, couponRepo.Create(context.Background(), validCoupon("c1", "PROMO")))
 	plan, _ := planRepo.FindActiveByID(context.Background(), "plus_monthly")
 
-	locked, redemptionID, err := uc.ApplyAtCheckout(context.Background(), "user-1", plan, "PROMO")
+	targetPlan, redemptionID, err := uc.ApplyAtCheckout(context.Background(), "user-1", plan, "PROMO")
 	assert.NoError(t, err)
-	assert.Equal(t, 7.0, locked)
+	assert.Equal(t, "plus_monthly_promo", targetPlan.ID)
+	assert.Equal(t, 7.0, targetPlan.Price)
 	assert.NotEqual(t, uuid.Nil, redemptionID)
 
 	red, err := redRepo.FindByID(context.Background(), redemptionID)
@@ -135,6 +145,7 @@ func TestCoupon_ApplyAtCheckout_CreatesPendingRedemption(t *testing.T) {
 	assert.Equal(t, domain.CouponRedemptionPending, red.Status)
 	assert.Equal(t, "user-1", red.UserID)
 	assert.Equal(t, 10.0, red.OriginalPrice)
+	assert.Equal(t, 7.0, red.LockedPrice)
 }
 
 func TestCoupon_ApplyAtCheckout_RefreshesPendingOnRetry(t *testing.T) {
@@ -146,10 +157,10 @@ func TestCoupon_ApplyAtCheckout_RefreshesPendingOnRetry(t *testing.T) {
 	assert.NoError(t, err)
 
 	// Second apply on abandoned PENDING must succeed and reuse the same redemption ID.
-	locked, secondID, err := uc.ApplyAtCheckout(context.Background(), "user-1", plan, "PROMO")
+	targetPlan, secondID, err := uc.ApplyAtCheckout(context.Background(), "user-1", plan, "PROMO")
 	assert.NoError(t, err)
 	assert.Equal(t, firstID, secondID, "should reuse the same redemption record")
-	assert.Equal(t, 7.0, locked)
+	assert.Equal(t, 7.0, targetPlan.Price)
 
 	red, err := redRepo.FindByID(context.Background(), secondID)
 	assert.NoError(t, err)

--- a/internal/usecase/subscription_usecase.go
+++ b/internal/usecase/subscription_usecase.go
@@ -200,9 +200,6 @@ func (s *Subscription) GetActivePlans(ctx context.Context) ([]domain.Subscriptio
 
 var validFrequencyTypes = map[string]bool{"months": true, "days": true}
 
-// CreatePlan persists a subscription plan and creates its matching preapproval_plan in
-// Mercado Pago, storing the returned id. reason/backURL are plan config (no longer env
-// vars). Promotional plans pass IsPublic=false so they stay out of the storefront.
 func (s *Subscription) CreatePlan(ctx context.Context, plan domain.SubscriptionPlan, reason, backURL string) error {
 	if plan.ID == "" {
 		return domain.WrapInvalidInput(domain.New("id is required"), "create plan")
@@ -223,8 +220,6 @@ func (s *Subscription) CreatePlan(ctx context.Context, plan domain.SubscriptionP
 		plan.Currency = "BRL"
 	}
 
-	// Create the preapproval_plan in Mercado Pago first so the persisted row always
-	// carries its mp_preapproval_plan_id (the invariant CreateCheckout relies on).
 	if plan.MPPreapprovalPlanID == "" {
 		cfg := gateway.SubscriptionPlanConfig{
 			Price:         plan.Price,

--- a/internal/usecase/subscription_usecase.go
+++ b/internal/usecase/subscription_usecase.go
@@ -6,7 +6,6 @@ import (
 	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"os"
 	"strings"
@@ -21,7 +20,8 @@ import (
 )
 
 type MercadoPagoSubscriptionGateway interface {
-	CreateSubscriptionURL(ctx context.Context, payerEmail, externalReference, backURL string, plan gateway.SubscriptionPlanConfig) (string, error)
+	CreatePlan(ctx context.Context, plan gateway.SubscriptionPlanConfig, reason, backURL string) (planID, initPoint string, err error)
+	BuildPlanCheckoutURL(planID, externalReference string) string
 	GetSubscription(ctx context.Context, id string) (gateway.MPSubscription, error)
 	CancelSubscription(ctx context.Context, id string) error
 }
@@ -59,6 +59,7 @@ type (
 		FindActive(ctx context.Context) ([]domain.SubscriptionPlan, error)
 		FindActiveByID(ctx context.Context, id string) (domain.SubscriptionPlan, error)
 		FindIDByStoreProduct(ctx context.Context, store, productID string) (string, error)
+		UpdateMPPlanID(ctx context.Context, planID, mpPlanID string) error
 	}
 
 	SubscriptionRepository interface {
@@ -67,13 +68,13 @@ type (
 	}
 
 	CouponCheckoutUseCase interface {
-		ApplyAtCheckout(ctx context.Context, userID string, plan domain.SubscriptionPlan, code string) (lockedPrice float64, redemptionID uuid.UUID, err error)
+		ApplyAtCheckout(ctx context.Context, userID string, plan domain.SubscriptionPlan, code string) (targetPlan domain.SubscriptionPlan, redemptionID uuid.UUID, err error)
 		Confirm(ctx context.Context, redemptionID, subscriptionID uuid.UUID) error
 		MarkCancelledBySubscription(ctx context.Context, subscriptionID uuid.UUID) error
 	}
 
 	SubscriptionUseCase interface {
-		CreateCheckout(ctx context.Context, planID, backURL, couponCode string) (string, error)
+		CreateCheckout(ctx context.Context, planID, couponCode string) (string, error)
 		CancelSubscription(ctx context.Context) error
 		HandleWebhook(ctx context.Context, xSignature, xRequestId string, body []byte) error
 		HandleRevenueCatWebhook(ctx context.Context, authHeader string, body []byte) error
@@ -113,7 +114,12 @@ type CheckoutResponse struct {
 	URL string `json:"checkout_url"`
 }
 
-func (s *Subscription) CreateCheckout(ctx context.Context, planID, backURL, couponCode string) (string, error) {
+// CreateCheckout resolves the Mercado Pago preapproval_plan the user should subscribe
+// to and returns its checkout URL. We never send a payer email: the subscriber logs
+// into their own MP account at the checkout, so there is no email-mismatch rejection.
+// When a coupon is applied it resolves 1:1 to a (non-public) promotional plan with its
+// own discounted preapproval_plan.
+func (s *Subscription) CreateCheckout(ctx context.Context, planID, couponCode string) (string, error) {
 	auth, ok := authentication.AuthFromContext(ctx)
 	if !ok {
 		return "", ErrUnauthorized
@@ -124,38 +130,25 @@ func (s *Subscription) CreateCheckout(ctx context.Context, planID, backURL, coup
 		return "", fmt.Errorf("%w: %v", ErrSubscriptionPlanNotFound, err)
 	}
 
-	payerEmail := auth.Email
-	if overrideEmail := os.Getenv("MERCADOPAGO_PAYER_EMAIL_OVERRIDE"); overrideEmail != "" {
-		payerEmail = overrideEmail
-	}
-
-	planConfig := gateway.SubscriptionPlanConfig{
-		Price:         plan.Price,
-		Currency:      plan.Currency,
-		Frequency:     plan.Frequency,
-		FrequencyType: plan.FrequencyType,
-	}
-
+	targetPlan := plan
 	var redemptionID uuid.UUID
 	if couponCode != "" {
-		lockedPrice, rID, err := s.couponUseCase.ApplyAtCheckout(ctx, auth.UserID, plan, couponCode)
+		promoPlan, rID, err := s.couponUseCase.ApplyAtCheckout(ctx, auth.UserID, plan, couponCode)
 		if err != nil {
 			return "", err
 		}
-		planConfig.Price = lockedPrice
+		targetPlan = promoPlan
 		redemptionID = rID
 	}
 
-	externalRef := buildExternalReference(auth.UserID, planID, redemptionID)
-	checkoutURL, err := s.mpGateway.CreateSubscriptionURL(ctx, payerEmail, externalRef, backURL, planConfig)
-	if err != nil {
-		if errors.Is(err, gateway.ErrCrossCountry) {
-			return "", fmt.Errorf("%w", ErrMPCrossCountry)
-		}
-		return "", fmt.Errorf("%w: %v", ErrMercadoPagoGateway, err)
+	if targetPlan.MPPreapprovalPlanID == "" {
+		return "", fmt.Errorf("%w: plan %s has no mercado pago plan configured", ErrMercadoPagoGateway, targetPlan.ID)
 	}
 
-	return checkoutURL, nil
+	// external_reference carries the base plan id so reporting stays keyed by the
+	// storefront plan; the actual charged price comes from the (promo) plan in MP.
+	externalRef := buildExternalReference(auth.UserID, plan.ID, redemptionID)
+	return s.mpGateway.BuildPlanCheckoutURL(targetPlan.MPPreapprovalPlanID, externalRef), nil
 }
 
 type SubscriptionsSummary struct {
@@ -207,7 +200,10 @@ func (s *Subscription) GetActivePlans(ctx context.Context) ([]domain.Subscriptio
 
 var validFrequencyTypes = map[string]bool{"months": true, "days": true}
 
-func (s *Subscription) CreatePlan(ctx context.Context, plan domain.SubscriptionPlan) error {
+// CreatePlan persists a subscription plan and creates its matching preapproval_plan in
+// Mercado Pago, storing the returned id. reason/backURL are plan config (no longer env
+// vars). Promotional plans pass IsPublic=false so they stay out of the storefront.
+func (s *Subscription) CreatePlan(ctx context.Context, plan domain.SubscriptionPlan, reason, backURL string) error {
 	if plan.ID == "" {
 		return domain.WrapInvalidInput(domain.New("id is required"), "create plan")
 	}
@@ -226,6 +222,23 @@ func (s *Subscription) CreatePlan(ctx context.Context, plan domain.SubscriptionP
 	if plan.Currency == "" {
 		plan.Currency = "BRL"
 	}
+
+	// Create the preapproval_plan in Mercado Pago first so the persisted row always
+	// carries its mp_preapproval_plan_id (the invariant CreateCheckout relies on).
+	if plan.MPPreapprovalPlanID == "" {
+		cfg := gateway.SubscriptionPlanConfig{
+			Price:         plan.Price,
+			Currency:      plan.Currency,
+			Frequency:     plan.Frequency,
+			FrequencyType: plan.FrequencyType,
+		}
+		mpPlanID, _, err := s.mpGateway.CreatePlan(ctx, cfg, reason, backURL)
+		if err != nil {
+			return fmt.Errorf("%w: %v", ErrMercadoPagoGateway, err)
+		}
+		plan.MPPreapprovalPlanID = mpPlanID
+	}
+
 	return s.planRepo.Create(ctx, plan)
 }
 
@@ -314,7 +327,10 @@ func (s *Subscription) HandleWebhook(ctx context.Context, xSignature, xRequestId
 
 	uid, planID, redemptionID := parseExternalReference(subscription.ExternalReference)
 	if uid == "" {
-		return fmt.Errorf("no external_reference (UID) found in subscription %s", event.Data.ID)
+		// No external_reference means we can't attribute this subscription to a user
+		// here. Return 200 so MP stops retrying; the authenticated confirm flow (if
+		// enabled) binds it on the web return instead.
+		return nil
 	}
 
 	var mpSubID string

--- a/internal/usecase/subscription_usecase.go
+++ b/internal/usecase/subscription_usecase.go
@@ -26,7 +26,7 @@ type MercadoPagoSubscriptionGateway interface {
 	CancelSubscription(ctx context.Context, id string) error
 }
 
-const externalReferenceSeparator = "|"
+const externalReferenceSeparator = "~"
 
 func buildExternalReference(userID, planID string, redemptionID uuid.UUID) string {
 	ref := userID + externalReferenceSeparator + planID

--- a/internal/usecase/subscription_usecase_test.go
+++ b/internal/usecase/subscription_usecase_test.go
@@ -18,9 +18,14 @@ type MockMPGateway struct {
 	mock.Mock
 }
 
-func (m *MockMPGateway) CreateSubscriptionURL(ctx context.Context, payerEmail, externalReference, backURL string, plan gateway.SubscriptionPlanConfig) (string, error) {
-	args := m.Called(ctx, payerEmail, externalReference, backURL, plan)
-	return args.String(0), args.Error(1)
+func (m *MockMPGateway) CreatePlan(ctx context.Context, plan gateway.SubscriptionPlanConfig, reason, backURL string) (string, string, error) {
+	args := m.Called(ctx, plan, reason, backURL)
+	return args.String(0), args.String(1), args.Error(2)
+}
+
+func (m *MockMPGateway) BuildPlanCheckoutURL(planID, externalReference string) string {
+	args := m.Called(planID, externalReference)
+	return args.String(0)
 }
 
 type MockSubscriptionPlanRepo struct {
@@ -45,6 +50,11 @@ func (m *MockSubscriptionPlanRepo) FindActiveByID(ctx context.Context, id string
 func (m *MockSubscriptionPlanRepo) FindIDByStoreProduct(ctx context.Context, store, productID string) (string, error) {
 	args := m.Called(ctx, store, productID)
 	return args.String(0), args.Error(1)
+}
+
+func (m *MockSubscriptionPlanRepo) UpdateMPPlanID(ctx context.Context, planID, mpPlanID string) error {
+	args := m.Called(ctx, planID, mpPlanID)
+	return args.Error(0)
 }
 
 func (m *MockMPGateway) GetSubscription(ctx context.Context, id string) (gateway.MPSubscription, error) {
@@ -81,51 +91,32 @@ func (m *MockFirebaseSubGateway) SetUserSubscription(ctx context.Context, userID
 }
 
 var monthlyPlan = domain.SubscriptionPlan{
-	ID:            "plus_monthly",
-	Name:          "Plus Mensal",
-	Price:         9.90,
-	Currency:      "BRL",
-	Frequency:     1,
-	FrequencyType: "months",
-	IsActive:      true,
-}
-
-var monthlyPlanConfig = gateway.SubscriptionPlanConfig{
-	Price:         9.90,
-	Currency:      "BRL",
-	Frequency:     1,
-	FrequencyType: "months",
+	ID:                  "plus_monthly",
+	Name:                "Plus Mensal",
+	Price:               9.90,
+	Currency:            "BRL",
+	Frequency:           1,
+	FrequencyType:       "months",
+	IsActive:            true,
+	IsPublic:            true,
+	MPPreapprovalPlanID: "mp-plan-monthly",
 }
 
 func TestSubscription_CreateCheckout(t *testing.T) {
 	tests := map[string]struct {
 		authCtx       *authentication.AuthContext
 		planID        string
-		backURL       string
 		mockSetup     func(*MockMPGateway, *MockSubscriptionPlanRepo)
 		expectedURL   string
 		expectedError error
 	}{
-		"should create checkout with back_url": {
+		"should build plan checkout url": {
 			authCtx: &authentication.AuthContext{UserID: "user-123"},
 			planID:  "plus_monthly",
-			backURL: "https://api.domain.com/subscription/return",
 			mockSetup: func(m *MockMPGateway, p *MockSubscriptionPlanRepo) {
 				p.On("FindActiveByID", mock.Anything, "plus_monthly").Return(monthlyPlan, nil)
-				m.On("CreateSubscriptionURL", mock.Anything, mock.Anything, "user-123|plus_monthly", "https://api.domain.com/subscription/return", monthlyPlanConfig).
-					Return("http://mp.com/pay", nil)
-			},
-			expectedURL:   "http://mp.com/pay",
-			expectedError: nil,
-		},
-		"should create checkout with empty back_url": {
-			authCtx: &authentication.AuthContext{UserID: "user-123"},
-			planID:  "plus_monthly",
-			backURL: "",
-			mockSetup: func(m *MockMPGateway, p *MockSubscriptionPlanRepo) {
-				p.On("FindActiveByID", mock.Anything, "plus_monthly").Return(monthlyPlan, nil)
-				m.On("CreateSubscriptionURL", mock.Anything, mock.Anything, "user-123|plus_monthly", "", monthlyPlanConfig).
-					Return("http://mp.com/pay", nil)
+				m.On("BuildPlanCheckoutURL", "mp-plan-monthly", "user-123|plus_monthly").
+					Return("http://mp.com/pay")
 			},
 			expectedURL:   "http://mp.com/pay",
 			expectedError: nil,
@@ -133,7 +124,6 @@ func TestSubscription_CreateCheckout(t *testing.T) {
 		"should return unauthorized if no user in context": {
 			authCtx:       nil,
 			planID:        "plus_monthly",
-			backURL:       "",
 			mockSetup:     func(m *MockMPGateway, p *MockSubscriptionPlanRepo) {},
 			expectedURL:   "",
 			expectedError: ErrUnauthorized,
@@ -141,21 +131,19 @@ func TestSubscription_CreateCheckout(t *testing.T) {
 		"should return error if plan not found": {
 			authCtx: &authentication.AuthContext{UserID: "user-123"},
 			planID:  "unknown_plan",
-			backURL: "",
 			mockSetup: func(m *MockMPGateway, p *MockSubscriptionPlanRepo) {
 				p.On("FindActiveByID", mock.Anything, "unknown_plan").Return(domain.SubscriptionPlan{}, errors.New("not found"))
 			},
 			expectedURL:   "",
 			expectedError: ErrSubscriptionPlanNotFound,
 		},
-		"should return gateway error if MP fails": {
+		"should fail when plan has no mercado pago plan configured": {
 			authCtx: &authentication.AuthContext{UserID: "user-123"},
 			planID:  "plus_monthly",
-			backURL: "",
 			mockSetup: func(m *MockMPGateway, p *MockSubscriptionPlanRepo) {
-				p.On("FindActiveByID", mock.Anything, "plus_monthly").Return(monthlyPlan, nil)
-				m.On("CreateSubscriptionURL", mock.Anything, mock.Anything, mock.Anything, mock.Anything, mock.Anything).
-					Return("", errors.New("mp error"))
+				unconfigured := monthlyPlan
+				unconfigured.MPPreapprovalPlanID = ""
+				p.On("FindActiveByID", mock.Anything, "plus_monthly").Return(unconfigured, nil)
 			},
 			expectedURL:   "",
 			expectedError: ErrMercadoPagoGateway,
@@ -176,7 +164,7 @@ func TestSubscription_CreateCheckout(t *testing.T) {
 				ctx = authentication.ContextWithAuth(ctx, *tc.authCtx)
 			}
 
-			resp, err := s.CreateCheckout(ctx, tc.planID, tc.backURL, "")
+			resp, err := s.CreateCheckout(ctx, tc.planID, "")
 
 			if tc.expectedError != nil {
 				assert.Error(t, err)

--- a/internal/usecase/subscription_usecase_test.go
+++ b/internal/usecase/subscription_usecase_test.go
@@ -115,7 +115,7 @@ func TestSubscription_CreateCheckout(t *testing.T) {
 			planID:  "plus_monthly",
 			mockSetup: func(m *MockMPGateway, p *MockSubscriptionPlanRepo) {
 				p.On("FindActiveByID", mock.Anything, "plus_monthly").Return(monthlyPlan, nil)
-				m.On("BuildPlanCheckoutURL", "mp-plan-monthly", "user-123|plus_monthly").
+				m.On("BuildPlanCheckoutURL", "mp-plan-monthly", "user-123~plus_monthly").
 					Return("http://mp.com/pay")
 			},
 			expectedURL:   "http://mp.com/pay",
@@ -322,7 +322,7 @@ func TestSubscription_HandleWebhook_MirrorsToDB(t *testing.T) {
 	mpResponse := gateway.MPSubscription{
 		ID:                "sub-123",
 		Status:            "authorized",
-		ExternalReference: "user-123|plus_monthly",
+		ExternalReference: "user-123~plus_monthly",
 		DateCreated:       "2026-01-10T12:00:00.000-03:00",
 		NextPaymentDate:   "2026-02-10T12:00:00.000-03:00",
 		AutoRecurring: gateway.MPAutoRecurring{


### PR DESCRIPTION
Switch the MP subscription flow from "subscription without plan"
(POST /preapproval with a fixed payer_email) to "subscription with
associated plan" (preapproval_plan + init_point). The subscriber logs
into their own MP account at checkout, so we never send a payer email
and the email-mismatch rejection that was costing sales is eliminated.

- Gateway: add CreatePlan (POST /preapproval_plan) and
  BuildPlanCheckoutURL; drop payer_email / CreateSubscriptionURL and the
  plan-config env vars (reason/back_url/currency now come from the DB).
- Plans: add mp_preapproval_plan_id and is_public to subscription_plans;
  admin create-plan also creates the MP plan and stores its id; the
  public storefront only lists public plans.
- Coupons: each coupon maps 1:1 to a non-public promotional plan via
  target_plan_id; checkout redirects to that promo plan's init_point.
  Redemption lifecycle (pending/active/cancelled) is unchanged.
- Webhook stays the primary attribution path via external_reference and
  now returns 200 (no error) when external_reference is absent.
- Remove the mobile deeplink return route (MP is web-only now; mobile
  uses RevenueCat).
- Migration 025; update tests and swagger docs.