### PR TITLE
Add business KPI metrics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+-
+
+## Release - v1.19.0 - 22-06-2026
+
+- Added business KPI metrics [PR#207](https://github.com/silvioubaldino/personal-finance/pull/207)
 - Improved logs and metrics [PR#205](https://github.com/silvioubaldino/personal-finance/pull/205)
 
 ## Release - v1.18.0 - 21-06-2026

--- a/internal/bootstrap/registry/plan_limits_validator.go
+++ b/internal/bootstrap/registry/plan_limits_validator.go
@@ -7,6 +7,7 @@ import (
 	"personal-finance/internal/infrastructure/repository"
 	"personal-finance/internal/plataform/authentication"
 	"personal-finance/internal/usecase"
+	"personal-finance/pkg/metrics"
 )
 
 type PlanLimitsValidator struct {
@@ -47,6 +48,7 @@ func (v *PlanLimitsValidator) ValidateWalletCreation(ctx context.Context) error 
 	}
 
 	if count >= int64(limits.Wallets) {
+		metrics.IncBusiness(ctx, "biz_plan_limit_hits_total", 1, metrics.String("limit_type", "wallet"))
 		return usecase.ErrWalletLimitReached
 	}
 
@@ -70,6 +72,7 @@ func (v *PlanLimitsValidator) ValidateCreditCardCreation(ctx context.Context) er
 	}
 
 	if count >= int64(limits.CreditCards) {
+		metrics.IncBusiness(ctx, "biz_plan_limit_hits_total", 1, metrics.String("limit_type", "credit_card"))
 		return usecase.ErrCreditCardLimitReached
 	}
 
@@ -94,6 +97,7 @@ func (v *PlanLimitsValidator) ValidateMovementCreation(ctx context.Context) erro
 	}
 
 	if count >= int64(limits.MovementsPerMonth) {
+		metrics.IncBusiness(ctx, "biz_plan_limit_hits_total", 1, metrics.String("limit_type", "movement"))
 		return usecase.ErrMovementLimitReached
 	}
 
@@ -118,6 +122,7 @@ func (v *PlanLimitsValidator) ValidateRecurrenceCreation(ctx context.Context) er
 	}
 
 	if count >= int64(limits.RecurrencesPerMonth) {
+		metrics.IncBusiness(ctx, "biz_plan_limit_hits_total", 1, metrics.String("limit_type", "recurrence"))
 		return usecase.ErrRecurrenceLimitReached
 	}
 

--- a/internal/infrastructure/gateway/adk_agent_gateway.go
+++ b/internal/infrastructure/gateway/adk_agent_gateway.go
@@ -19,6 +19,7 @@ import (
 	"personal-finance/internal/domain"
 	"personal-finance/internal/plataform/authentication"
 	"personal-finance/pkg/log"
+	"personal-finance/pkg/metrics"
 )
 
 const (
@@ -231,6 +232,8 @@ func (g *ADKAgentGateway) Chat(
 			}
 		}
 	}
+
+	metrics.IncAITokens(ctx, "agent", g.modelName, inputTokens, outputTokens)
 
 	return domain.AgentGatewayResponse{
 		Content:      responseBuilder.String(),

--- a/internal/infrastructure/gateway/gemini_classification_gateway.go
+++ b/internal/infrastructure/gateway/gemini_classification_gateway.go
@@ -95,6 +95,8 @@ func (g *GeminiClassificationGateway) ClassifyMovements(
 		return nil, fmt.Errorf("gemini classification call failed: %w", err)
 	}
 
+	recordTokenUsage(ctx, "statement_classify", g.modelName, resp)
+
 	var responseText string
 	if resp != nil && len(resp.Candidates) > 0 && resp.Candidates[0].Content != nil {
 		for _, part := range resp.Candidates[0].Content.Parts {

--- a/internal/infrastructure/gateway/gemini_vision_gateway.go
+++ b/internal/infrastructure/gateway/gemini_vision_gateway.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"personal-finance/internal/domain"
+	"personal-finance/pkg/metrics"
 
 	"google.golang.org/genai"
 )
@@ -86,6 +87,8 @@ func (g *GeminiVisionGateway) ExtractMovements(ctx context.Context, fileBytes []
 		return domain.StatementExtractResult{}, fmt.Errorf("gemini vision call failed: %w", err)
 	}
 
+	recordTokenUsage(ctx, "statement_extract", g.modelName, resp)
+
 	var responseText string
 	if resp != nil && len(resp.Candidates) > 0 && resp.Candidates[0].Content != nil {
 		for _, part := range resp.Candidates[0].Content.Parts {
@@ -133,6 +136,19 @@ func (g *GeminiVisionGateway) ExtractMovements(ctx context.Context, fileBytes []
 		Movements: valid,
 		Errors:    errors,
 	}, nil
+}
+
+// recordTokenUsage emits the unified biz_ai_tokens_total KPI from a Gemini
+// GenerateContent response, attributing the cost to the given feature/model.
+// It is a no-op when the model returns no usage metadata.
+func recordTokenUsage(ctx context.Context, feature, model string, resp *genai.GenerateContentResponse) {
+	if resp == nil || resp.UsageMetadata == nil {
+		return
+	}
+	metrics.IncAITokens(ctx, feature, model,
+		int(resp.UsageMetadata.PromptTokenCount),
+		int(resp.UsageMetadata.CandidatesTokenCount),
+	)
 }
 
 func cleanJSONResponse(s string) string {

--- a/internal/usecase/invoice_usecase.go
+++ b/internal/usecase/invoice_usecase.go
@@ -9,6 +9,7 @@ import (
 	"personal-finance/internal/domain"
 	"personal-finance/internal/infrastructure/repository"
 	"personal-finance/internal/infrastructure/repository/transaction"
+	"personal-finance/pkg/metrics"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -108,6 +109,8 @@ func (uc Invoice) create(ctx context.Context, creditCardID uuid.UUID, movementDa
 	if err != nil {
 		return domain.Invoice{}, err
 	}
+
+	metrics.IncBusiness(ctx, "biz_invoices_generated_total", 1)
 
 	return result, nil
 }
@@ -253,6 +256,8 @@ func (uc Invoice) Pay(ctx context.Context, id uuid.UUID, walletID uuid.UUID, pay
 	if err != nil {
 		return domain.Invoice{}, err
 	}
+
+	metrics.IncBusiness(ctx, "biz_invoices_paid_total", 1)
 
 	return result, nil
 }

--- a/internal/usecase/statement_usecase.go
+++ b/internal/usecase/statement_usecase.go
@@ -8,6 +8,7 @@ import (
 	"personal-finance/internal/domain"
 	"personal-finance/internal/plataform/authentication"
 	"personal-finance/pkg/log"
+	"personal-finance/pkg/metrics"
 
 	"github.com/google/uuid"
 	"gorm.io/gorm"
@@ -107,6 +108,10 @@ func (u *StatementUseCase) Extract(ctx context.Context, fileBytes []byte, mimeTy
 	if err != nil {
 		return domain.StatementExtractResult{}, fmt.Errorf("extract movements: %w", err)
 	}
+
+	metrics.IncBusiness(ctx, "biz_statement_imports_total", 1,
+		metrics.String("mime_type", mimeType),
+	)
 
 	return result, nil
 }
@@ -336,6 +341,10 @@ func (u *StatementUseCase) Confirm(ctx context.Context, input domain.StatementCo
 
 		existingHashes[hash] = true
 		created++
+	}
+
+	if created > 0 {
+		metrics.IncBusiness(ctx, "biz_statement_movements_imported_total", int64(created))
 	}
 
 	return domain.StatementConfirmResult{

--- a/pkg/metrics/business.go
+++ b/pkg/metrics/business.go
@@ -48,6 +48,29 @@ func IncBusiness(ctx context.Context, name string, value int64, labels ...Label)
 	counter.Add(ctx, value, metric.WithAttributes(attrs...))
 }
 
+// IncAITokens records LLM token usage on the unified biz_ai_tokens_total
+// counter, split by kind ("input"/"output"). feature identifies the call site
+// (e.g. "agent", "statement_extract", "statement_classify") and model is the
+// LLM model name. All three labels are low-cardinality, so the series count
+// stays bounded (features × kinds × models). Non-positive counts are skipped so
+// a kind that produced no tokens does not create an empty series.
+func IncAITokens(ctx context.Context, feature, model string, inputTokens, outputTokens int) {
+	if inputTokens > 0 {
+		IncBusiness(ctx, "biz_ai_tokens_total", int64(inputTokens),
+			String("feature", feature),
+			String("kind", "input"),
+			String("model", model),
+		)
+	}
+	if outputTokens > 0 {
+		IncBusiness(ctx, "biz_ai_tokens_total", int64(outputTokens),
+			String("feature", feature),
+			String("kind", "output"),
+			String("model", model),
+		)
+	}
+}
+
 func businessCounter(name string) metric.Int64Counter {
 	name = withBizPrefix(name)
 


### PR DESCRIPTION
…imports and plan limits

Instrument the AyD §6.2 catalog with new biz_* counters:

- biz_ai_tokens_total{feature,kind,model}: unified LLM token cost across the agent and statement (extract/classify) flows. New metrics.IncAITokens helper emits input/output kinds; gateways read the previously-discarded genai UsageMetadata via a shared recordTokenUsage helper.
- biz_invoices_generated_total / biz_invoices_paid_total
- biz_statement_imports_total{mime_type} + biz_statement_movements_imported_total
- biz_plan_limit_hits_total{limit_type}: emitted at the 4 enforcement points, so import flows hitting the movement limit are counted too.

All labels are low-cardinality, keeping the series count well within the Cloud Monitoring free-tier budget.