### PR TITLE
feat(dashboard): endpoint de agregação financeira mensal

### DIFF
--- a/internal/bootstrap/dashboard/setup.go
+++ b/internal/bootstrap/dashboard/setup.go
@@ -1,0 +1,16 @@
+package dashboard
+
+import (
+	"personal-finance/internal/bootstrap/registry"
+	"personal-finance/internal/infrastructure/api"
+	"personal-finance/internal/usecase"
+
+	"github.com/gin-gonic/gin"
+)
+
+func Setup(r *gin.Engine, reg *registry.Registry) {
+	movementRepo := reg.GetMovementRepository()
+	estimateRepo := reg.GetEstimateRepository()
+	dashboardService := usecase.NewDashboard(movementRepo, estimateRepo)
+	api.NewDashboardV2Handlers(r, dashboardService)
+}

--- a/internal/bootstrap/setup.go
+++ b/internal/bootstrap/setup.go
@@ -7,6 +7,7 @@ import (
 	"personal-finance/internal/bootstrap/category"
 	"personal-finance/internal/bootstrap/coupon"
 	"personal-finance/internal/bootstrap/creditcard"
+	"personal-finance/internal/bootstrap/dashboard"
 	"personal-finance/internal/bootstrap/deleteaccount"
 	"personal-finance/internal/bootstrap/device"
 	"personal-finance/internal/bootstrap/estimate"
@@ -69,6 +70,7 @@ func SetupCleanArchComponents(r *gin.Engine, db *gorm.DB, auth authentication.Au
 	wallet.Setup(r, reg)
 	estimate.Setup(r, reg)
 	balance.Setup(r, reg)
+	dashboard.Setup(r, reg)
 	coupon.Setup(r, reg)
 	telemetry.Setup(r, reg)
 }

--- a/internal/domain/dashboard.go
+++ b/internal/domain/dashboard.go
@@ -1,0 +1,48 @@
+package domain
+
+type (
+	// DashboardSummary aggregates financial data for the analytics screen.
+	DashboardSummary struct {
+		MonthlySeries []MonthlyPoint   `json:"monthly_series"`
+		CurrentMonth  BudgetComparison `json:"current_month"`
+		KPIs          DashboardKPIs    `json:"kpis"`
+	}
+
+	// MonthlyPoint is one calendar month entry in the chart series.
+	MonthlyPoint struct {
+		Month   int     `json:"month"`
+		Year    int     `json:"year"`
+		Income  float64 `json:"income"`
+		Expense float64 `json:"expense"`
+		Net     float64 `json:"net"`
+	}
+
+	// BudgetComparison holds budgeted vs realized values for a single month.
+	BudgetComparison struct {
+		Month  int             `json:"month"`
+		Year   int             `json:"year"`
+		Budget DashboardBudget `json:"budget"`
+	}
+
+	// DashboardBudget groups income and expense budget lines.
+	DashboardBudget struct {
+		Income  BudgetLine `json:"income"`
+		Expense BudgetLine `json:"expense"`
+	}
+
+	// BudgetLine compares the budgeted value against the realized one.
+	BudgetLine struct {
+		Budgeted float64 `json:"budgeted"`
+		Realized float64 `json:"realized"`
+	}
+
+	// DashboardKPIs summarizes the whole period.
+	DashboardKPIs struct {
+		TotalIncome       float64 `json:"total_income"`
+		TotalExpense      float64 `json:"total_expense"`
+		AvgMonthlyIncome  float64 `json:"avg_monthly_income"`
+		AvgMonthlyExpense float64 `json:"avg_monthly_expense"`
+		PeriodNet         float64 `json:"period_net"`
+		SavingsRate       float64 `json:"savings_rate"`
+	}
+)

--- a/internal/infrastructure/api/dashboard_api.go
+++ b/internal/infrastructure/api/dashboard_api.go
@@ -1,0 +1,59 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"time"
+
+	"personal-finance/internal/domain"
+
+	"github.com/gin-gonic/gin"
+)
+
+type (
+	DashboardUsecase interface {
+		CalculateSummary(ctx context.Context, period domain.Period) (domain.DashboardSummary, error)
+	}
+
+	DashboardHandler struct {
+		usecase DashboardUsecase
+	}
+)
+
+func NewDashboardV2Handlers(r *gin.Engine, srv DashboardUsecase) {
+	handler := DashboardHandler{usecase: srv}
+	r.GET("/v2/dashboard/summary", handler.GetSummary())
+}
+
+func (h DashboardHandler) GetSummary() gin.HandlerFunc {
+	return func(c *gin.Context) {
+		ctx := c.Request.Context()
+
+		var period domain.Period
+		var err error
+
+		if fromString := c.Query("from"); fromString != "" {
+			period.From, err = time.Parse("2006-01-02", fromString)
+			if err != nil {
+				HandleErr(c, ctx, domain.WrapInvalidInput(err, "invalid from date format"))
+				return
+			}
+		}
+
+		if toString := c.Query("to"); toString != "" {
+			period.To, err = time.Parse("2006-01-02", toString)
+			if err != nil {
+				HandleErr(c, ctx, domain.WrapInvalidInput(err, "invalid to date format"))
+				return
+			}
+		}
+
+		summary, err := h.usecase.CalculateSummary(ctx, period)
+		if err != nil {
+			HandleErr(c, ctx, err)
+			return
+		}
+
+		c.JSON(http.StatusOK, summary)
+	}
+}

--- a/internal/usecase/dashboard_usecase.go
+++ b/internal/usecase/dashboard_usecase.go
@@ -1,0 +1,201 @@
+package usecase
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"personal-finance/internal/domain"
+)
+
+type DashboardMovementRepository interface {
+	FindByPeriod(ctx context.Context, period domain.Period) (domain.MovementList, error)
+}
+
+type DashboardEstimateRepository interface {
+	FindCategoriesByMonth(ctx context.Context, month int, year int) ([]domain.EstimateCategories, error)
+}
+
+type DashboardUseCase interface {
+	CalculateSummary(ctx context.Context, period domain.Period) (domain.DashboardSummary, error)
+}
+
+type dashboardUseCase struct {
+	movementRepo DashboardMovementRepository
+	estimateRepo DashboardEstimateRepository
+}
+
+func NewDashboard(movementRepo DashboardMovementRepository, estimateRepo DashboardEstimateRepository) DashboardUseCase {
+	return dashboardUseCase{
+		movementRepo: movementRepo,
+		estimateRepo: estimateRepo,
+	}
+}
+
+func (uc dashboardUseCase) CalculateSummary(ctx context.Context, period domain.Period) (domain.DashboardSummary, error) {
+	if err := period.Validate(); err != nil {
+		return domain.DashboardSummary{}, fmt.Errorf("período inválido: %w", err)
+	}
+
+	movements, err := uc.movementRepo.FindByPeriod(ctx, period)
+	if err != nil {
+		return domain.DashboardSummary{}, fmt.Errorf("error finding movements: %w", err)
+	}
+
+	paid := movements.GetPaidMovements()
+
+	monthlySeries := buildMonthlySeries(period, paid)
+
+	currentMonth, err := uc.buildCurrentMonth(ctx, period, paid)
+	if err != nil {
+		return domain.DashboardSummary{}, err
+	}
+
+	kpis := buildKPIs(monthlySeries)
+
+	return domain.DashboardSummary{
+		MonthlySeries: monthlySeries,
+		CurrentMonth:  currentMonth,
+		KPIs:          kpis,
+	}, nil
+}
+
+// monthKey uniquely identifies a calendar month.
+type monthKey struct {
+	month int
+	year  int
+}
+
+// buildMonthlySeries produces one ordered entry per calendar month in [from,to],
+// filling months with no activity as zeros so the chart axis stays continuous.
+func buildMonthlySeries(period domain.Period, paid domain.MovementList) []domain.MonthlyPoint {
+	incomeByMonth := make(map[monthKey]float64)
+	expenseByMonth := make(map[monthKey]float64)
+
+	for _, m := range paid.GetIncomeMovements() {
+		k := keyFromTime(*m.Date)
+		incomeByMonth[k] += m.Amount
+	}
+	for _, m := range paid.GetExpenseMovements() {
+		k := keyFromTime(*m.Date)
+		expenseByMonth[k] += m.Amount
+	}
+
+	var series []domain.MonthlyPoint
+	cursor := time.Date(period.From.Year(), period.From.Month(), 1, 0, 0, 0, 0, time.UTC)
+	end := time.Date(period.To.Year(), period.To.Month(), 1, 0, 0, 0, 0, time.UTC)
+	for !cursor.After(end) {
+		k := monthKey{month: int(cursor.Month()), year: cursor.Year()}
+		income := incomeByMonth[k]
+		expense := expenseByMonth[k]
+		series = append(series, domain.MonthlyPoint{
+			Month:   k.month,
+			Year:    k.year,
+			Income:  income,
+			Expense: expense,
+			Net:     income + expense,
+		})
+		cursor = cursor.AddDate(0, 1, 0)
+	}
+
+	return series
+}
+
+// buildCurrentMonth computes budgeted vs realized for the month of period.To.
+func (uc dashboardUseCase) buildCurrentMonth(
+	ctx context.Context,
+	period domain.Period,
+	paid domain.MovementList,
+) (domain.BudgetComparison, error) {
+	month := int(period.To.Month())
+	year := period.To.Year()
+
+	estimates, err := uc.estimateRepo.FindCategoriesByMonth(ctx, month, year)
+	if err != nil {
+		return domain.BudgetComparison{}, fmt.Errorf("error finding estimates: %w", err)
+	}
+
+	estimateList := domain.EstimateCategoriesList(estimates)
+
+	paid = filterByMonth(paid, month, year)
+
+	expenseSumByCategory := paid.GetExpenseMovements().GetSumByCategory()
+	expenseEstimates := estimateList.GetExpenseEstimates().GetEstimateByCategory()
+	expenseBudgeted := sumMapValues(expenseEstimates)
+	expenseRealized := getBalanceSum(expenseEstimates, expenseSumByCategory, false)
+
+	incomeSumByCategory := paid.GetIncomeMovements().GetSumByCategory()
+	incomeEstimates := estimateList.GetIncomeEstimates().GetEstimateByCategory()
+	incomeBudgeted := sumMapValues(incomeEstimates)
+	incomeRealized := getBalanceSum(incomeEstimates, incomeSumByCategory, true)
+
+	return domain.BudgetComparison{
+		Month: month,
+		Year:  year,
+		Budget: domain.DashboardBudget{
+			Income: domain.BudgetLine{
+				Budgeted: incomeBudgeted,
+				Realized: incomeRealized,
+			},
+			Expense: domain.BudgetLine{
+				Budgeted: expenseBudgeted,
+				Realized: expenseRealized,
+			},
+		},
+	}, nil
+}
+
+// buildKPIs aggregates the monthly series into period-wide totals and averages.
+func buildKPIs(series []domain.MonthlyPoint) domain.DashboardKPIs {
+	var totalIncome, totalExpense float64
+	for _, p := range series {
+		totalIncome += p.Income
+		totalExpense += p.Expense
+	}
+
+	months := float64(len(series))
+	var avgIncome, avgExpense float64
+	if months > 0 {
+		avgIncome = totalIncome / months
+		avgExpense = totalExpense / months
+	}
+
+	periodNet := totalIncome + totalExpense
+
+	var savingsRate float64
+	if totalIncome > 0 {
+		savingsRate = periodNet / totalIncome
+	}
+
+	return domain.DashboardKPIs{
+		TotalIncome:       totalIncome,
+		TotalExpense:      totalExpense,
+		AvgMonthlyIncome:  avgIncome,
+		AvgMonthlyExpense: avgExpense,
+		PeriodNet:         periodNet,
+		SavingsRate:       savingsRate,
+	}
+}
+
+// filterByMonth returns only movements whose date falls in the given month/year.
+func filterByMonth(movements domain.MovementList, month, year int) domain.MovementList {
+	var filtered domain.MovementList
+	for _, m := range movements {
+		if m.Date != nil && int(m.Date.Month()) == month && m.Date.Year() == year {
+			filtered = append(filtered, m)
+		}
+	}
+	return filtered
+}
+
+func keyFromTime(t time.Time) monthKey {
+	return monthKey{month: int(t.Month()), year: t.Year()}
+}
+
+func sumMapValues[K comparable](m map[K]float64) float64 {
+	var total float64
+	for _, v := range m {
+		total += v
+	}
+	return total
+}

--- a/internal/usecase/dashboard_usecase_test.go
+++ b/internal/usecase/dashboard_usecase_test.go
@@ -1,0 +1,275 @@
+package usecase
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"personal-finance/internal/domain"
+
+	"github.com/google/uuid"
+	"github.com/stretchr/testify/assert"
+)
+
+func dashboardDate(year int, month time.Month, day int) *time.Time {
+	t := time.Date(year, month, day, 0, 0, 0, 0, time.UTC)
+	return &t
+}
+
+func dashboardMovement(amount float64, date *time.Time, isPaid bool) domain.Movement {
+	categoryID := uuid.New()
+	return dashboardMovementWithCategory(amount, date, isPaid, &categoryID)
+}
+
+func dashboardMovementWithCategory(amount float64, date *time.Time, isPaid bool, categoryID *uuid.UUID) domain.Movement {
+	return domain.Movement{
+		Amount:     amount,
+		Date:       date,
+		IsPaid:     isPaid,
+		CategoryID: categoryID,
+		Category:   domain.Category{ID: categoryID},
+	}
+}
+
+func dashboardEstimate(amount float64, isIncome bool, categoryID *uuid.UUID) domain.EstimateCategories {
+	return domain.EstimateCategories{
+		CategoryID:       categoryID,
+		IsCategoryIncome: isIncome,
+		Amount:           amount,
+	}
+}
+
+func TestDashboard_CalculateSummary(t *testing.T) {
+	type (
+		input struct {
+			period domain.Period
+		}
+		expected struct {
+			output domain.DashboardSummary
+			err    error
+		}
+	)
+
+	tests := map[string]struct {
+		// input
+		input input
+		// mocks
+		mockSetup func(mockMovRepo *MockMovementRepository, mockEstRepo *MockEstimateRepository)
+		// expected
+		expected expected
+	}{
+		"should build multi-month series filling gaps with zeros when months have no activity": {
+			input: input{period: domain.Period{
+				From: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+				To:   time.Date(2026, time.March, 31, 0, 0, 0, 0, time.UTC),
+			}},
+			mockSetup: func(mockMovRepo *MockMovementRepository, mockEstRepo *MockEstimateRepository) {
+				period := domain.Period{
+					From: time.Date(2026, time.January, 1, 0, 0, 0, 0, time.UTC),
+					To:   time.Date(2026, time.March, 31, 0, 0, 0, 0, time.UTC),
+				}
+				movements := domain.MovementList{
+					dashboardMovement(5000, dashboardDate(2026, time.January, 10), true),
+					dashboardMovement(-3000, dashboardDate(2026, time.January, 15), true),
+					// February intentionally empty.
+					dashboardMovement(4000, dashboardDate(2026, time.March, 5), true),
+					dashboardMovement(-1000, dashboardDate(2026, time.March, 8), true),
+				}
+				mockMovRepo.On("FindByPeriod", period).Return(movements, nil)
+				mockEstRepo.On("FindCategoriesByMonth", 3, 2026).
+					Return([]domain.EstimateCategories{}, nil)
+			},
+			expected: expected{
+				output: domain.DashboardSummary{
+					MonthlySeries: []domain.MonthlyPoint{
+						{Month: 1, Year: 2026, Income: 5000, Expense: -3000, Net: 2000},
+						{Month: 2, Year: 2026, Income: 0, Expense: 0, Net: 0},
+						{Month: 3, Year: 2026, Income: 4000, Expense: -1000, Net: 3000},
+					},
+					CurrentMonth: domain.BudgetComparison{
+						Month: 3, Year: 2026,
+						Budget: domain.DashboardBudget{
+							Income:  domain.BudgetLine{Budgeted: 0, Realized: 4000},
+							Expense: domain.BudgetLine{Budgeted: 0, Realized: -1000},
+						},
+					},
+					KPIs: domain.DashboardKPIs{
+						TotalIncome:       9000,
+						TotalExpense:      -4000,
+						AvgMonthlyIncome:  3000,
+						AvgMonthlyExpense: -4000.0 / 3.0,
+						PeriodNet:         5000,
+						SavingsRate:       5000.0 / 9000.0,
+					},
+				},
+				err: nil,
+			},
+		},
+		"should compute budget vs realized for current month using paid movements": {
+			input: input{period: domain.Period{
+				From: time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+				To:   time.Date(2026, time.June, 30, 0, 0, 0, 0, time.UTC),
+			}},
+			mockSetup: func(mockMovRepo *MockMovementRepository, mockEstRepo *MockEstimateRepository) {
+				period := domain.Period{
+					From: time.Date(2026, time.June, 1, 0, 0, 0, 0, time.UTC),
+					To:   time.Date(2026, time.June, 30, 0, 0, 0, 0, time.UTC),
+				}
+				incomeCat := uuid.New()
+				expenseCat := uuid.New()
+				movements := domain.MovementList{
+					dashboardMovementWithCategory(4800, dashboardDate(2026, time.June, 10), true, &incomeCat),
+					dashboardMovementWithCategory(-3200, dashboardDate(2026, time.June, 12), true, &expenseCat),
+					// Unpaid movement must be ignored.
+					dashboardMovementWithCategory(-1000, dashboardDate(2026, time.June, 20), false, &expenseCat),
+				}
+				mockMovRepo.On("FindByPeriod", period).Return(movements, nil)
+				mockEstRepo.On("FindCategoriesByMonth", 6, 2026).Return([]domain.EstimateCategories{
+					dashboardEstimate(5000, true, &incomeCat),
+					dashboardEstimate(-3000, false, &expenseCat),
+				}, nil)
+			},
+			expected: expected{
+				output: domain.DashboardSummary{
+					MonthlySeries: []domain.MonthlyPoint{
+						{Month: 6, Year: 2026, Income: 4800, Expense: -3200, Net: 1600},
+					},
+					CurrentMonth: domain.BudgetComparison{
+						Month: 6, Year: 2026,
+						Budget: domain.DashboardBudget{
+							Income:  domain.BudgetLine{Budgeted: 5000, Realized: 5000},
+							Expense: domain.BudgetLine{Budgeted: -3000, Realized: -3200},
+						},
+					},
+					KPIs: domain.DashboardKPIs{
+						TotalIncome:       4800,
+						TotalExpense:      -3200,
+						AvgMonthlyIncome:  4800,
+						AvgMonthlyExpense: -3200,
+						PeriodNet:         1600,
+						SavingsRate:       1600.0 / 4800.0,
+					},
+				},
+				err: nil,
+			},
+		},
+		"should return zero savings rate when total income is zero": {
+			input: input{period: domain.Period{
+				From: time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC),
+				To:   time.Date(2026, time.May, 31, 0, 0, 0, 0, time.UTC),
+			}},
+			mockSetup: func(mockMovRepo *MockMovementRepository, mockEstRepo *MockEstimateRepository) {
+				period := domain.Period{
+					From: time.Date(2026, time.May, 1, 0, 0, 0, 0, time.UTC),
+					To:   time.Date(2026, time.May, 31, 0, 0, 0, 0, time.UTC),
+				}
+				movements := domain.MovementList{
+					dashboardMovement(-2000, dashboardDate(2026, time.May, 10), true),
+				}
+				mockMovRepo.On("FindByPeriod", period).Return(movements, nil)
+				mockEstRepo.On("FindCategoriesByMonth", 5, 2026).
+					Return([]domain.EstimateCategories{}, nil)
+			},
+			expected: expected{
+				output: domain.DashboardSummary{
+					MonthlySeries: []domain.MonthlyPoint{
+						{Month: 5, Year: 2026, Income: 0, Expense: -2000, Net: -2000},
+					},
+					CurrentMonth: domain.BudgetComparison{
+						Month: 5, Year: 2026,
+						Budget: domain.DashboardBudget{
+							Income:  domain.BudgetLine{Budgeted: 0, Realized: 0},
+							Expense: domain.BudgetLine{Budgeted: 0, Realized: -2000},
+						},
+					},
+					KPIs: domain.DashboardKPIs{
+						TotalIncome:       0,
+						TotalExpense:      -2000,
+						AvgMonthlyIncome:  0,
+						AvgMonthlyExpense: -2000,
+						PeriodNet:         -2000,
+						SavingsRate:       0,
+					},
+				},
+				err: nil,
+			},
+		},
+		"should return zeroed summary when period has no movements": {
+			input: input{period: domain.Period{
+				From: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+				To:   time.Date(2026, time.April, 30, 0, 0, 0, 0, time.UTC),
+			}},
+			mockSetup: func(mockMovRepo *MockMovementRepository, mockEstRepo *MockEstimateRepository) {
+				period := domain.Period{
+					From: time.Date(2026, time.April, 1, 0, 0, 0, 0, time.UTC),
+					To:   time.Date(2026, time.April, 30, 0, 0, 0, 0, time.UTC),
+				}
+				mockMovRepo.On("FindByPeriod", period).Return(domain.MovementList{}, nil)
+				mockEstRepo.On("FindCategoriesByMonth", 4, 2026).
+					Return([]domain.EstimateCategories{}, nil)
+			},
+			expected: expected{
+				output: domain.DashboardSummary{
+					MonthlySeries: []domain.MonthlyPoint{
+						{Month: 4, Year: 2026, Income: 0, Expense: 0, Net: 0},
+					},
+					CurrentMonth: domain.BudgetComparison{
+						Month: 4, Year: 2026,
+						Budget: domain.DashboardBudget{
+							Income:  domain.BudgetLine{Budgeted: 0, Realized: 0},
+							Expense: domain.BudgetLine{Budgeted: 0, Realized: 0},
+						},
+					},
+					KPIs: domain.DashboardKPIs{
+						TotalIncome:       0,
+						TotalExpense:      0,
+						AvgMonthlyIncome:  0,
+						AvgMonthlyExpense: 0,
+						PeriodNet:         0,
+						SavingsRate:       0,
+					},
+				},
+				err: nil,
+			},
+		},
+		"should return error when movement repository fails": {
+			input: input{period: domain.Period{
+				From: time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+				To:   time.Date(2026, time.July, 31, 0, 0, 0, 0, time.UTC),
+			}},
+			mockSetup: func(mockMovRepo *MockMovementRepository, mockEstRepo *MockEstimateRepository) {
+				period := domain.Period{
+					From: time.Date(2026, time.July, 1, 0, 0, 0, 0, time.UTC),
+					To:   time.Date(2026, time.July, 31, 0, 0, 0, 0, time.UTC),
+				}
+				mockMovRepo.On("FindByPeriod", period).
+					Return(domain.MovementList{}, assert.AnError)
+			},
+			expected: expected{
+				output: domain.DashboardSummary{},
+				err:    assert.AnError,
+			},
+		},
+	}
+
+	for name, tc := range tests {
+		t.Run(name, func(t *testing.T) {
+			// Arrange
+			var (
+				mockMovRepo = &MockMovementRepository{}
+				mockEstRepo = &MockEstimateRepository{}
+				uc          = NewDashboard(mockMovRepo, mockEstRepo)
+			)
+			defer mockMovRepo.AssertExpectations(t)
+			defer mockEstRepo.AssertExpectations(t)
+			tc.mockSetup(mockMovRepo, mockEstRepo)
+
+			// Act
+			output, err := uc.CalculateSummary(context.Background(), tc.input.period)
+
+			// Assert
+			assert.ErrorIs(t, err, tc.expected.err)
+			assert.Equal(t, tc.expected.output, output)
+		})
+	}
+}

--- a/internal/usecase/mocks.go
+++ b/internal/usecase/mocks.go
@@ -85,6 +85,15 @@ func (m *MockMovementRepository) RevertPayByInvoiceID(_ context.Context, tx *gor
 	return args.Error(0)
 }
 
+type MockEstimateRepository struct {
+	mock.Mock
+}
+
+func (m *MockEstimateRepository) FindCategoriesByMonth(_ context.Context, month int, year int) ([]domain.EstimateCategories, error) {
+	args := m.Called(month, year)
+	return args.Get(0).([]domain.EstimateCategories), args.Error(1)
+}
+
 type MockRecurrentRepository struct {
 	mock.Mock
 }


### PR DESCRIPTION
## Contexto

Suporte de backend para a nova tela de **Análises** do app mobile. Hoje o app só tem visão de mês único; esta feature expõe agregações ao longo do tempo para alimentar gráficos de Renda vs Despesa, Orçado vs Realizado e KPIs.

## O que muda

Nova feature **clean-architecture** `dashboard`, espelhando o padrão do `balance`.

**Endpoint:** `GET /v2/dashboard/summary?from=YYYY-MM-DD&to=YYYY-MM-DD`

Retorna:
- `monthly_series` — renda/despesa/saldo por mês (meses sem movimento vêm zerados, para eixo contínuo no gráfico). Realizado = movimentos **pagos**.
- `current_month.budget` — orçado vs realizado (renda e despesa) do mês selecionado (mês de `to`), reutilizando a lógica de teto/piso do `balance` (`getBalanceSum`).
- `kpis` — totais, médias mensais, saldo do período e `savings_rate` (= `period_net / total_income`, 0 quando renda ≤ 0).

### Arquivos
**Criados:** `internal/domain/dashboard.go`, `internal/usecase/dashboard_usecase.go` (+ `dashboard_usecase_test.go`), `internal/infrastructure/api/dashboard_api.go`, `internal/bootstrap/dashboard/setup.go`.
**Modificados:** `internal/bootstrap/setup.go` (registra `dashboard.Setup`), `internal/usecase/mocks.go` (novo `MockEstimateRepository`).

## Nota de design
Como o período do dashboard abrange vários meses (diferente do `balance`, que é mês único), os movimentos pagos são filtrados ao mês de `to` antes de computar o comparativo orçado vs realizado.

## Verificação
- `go build ./...`, `gofumpt`, `goimports`, `go vet`: limpos nos arquivos novos/alterados.
- Testes do usecase `dashboard`: **5 casos passando** (série multi-mês com lacunas, savings_rate normal e com renda zero, orçado vs realizado ignorando não-pagos, erro de repositório). Pacote `internal/infrastructure/api` passa.

⚠️ **Pré-existentes (não causados por esta PR):** `golangci-lint` e `make test` falham em arquivos não relacionados (`internal/domain/category/api/handler_test.go`, `internal/domain/movement/repository/movements_test.go`, `TestPushNotifications_SendDailyUnpaidPush`) — confirmado rodando na base sem estes arquivos.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01S9jT4zwZvcMNtAyCnfcEUL)_