### PR TITLE
Adopt specs-driven docs framework

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -57,3 +57,6 @@ specs/*
 .claude/*
 !.claude/skills
 !.claude/skills/**
+
+# Docs framework — read-only mirror of the context repo (personal-finance-context)
+docs/shared/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- Added docs framework structure [PR#215](https://github.com/silvioubaldino/personal-finance/pull/215)
 - Removed unused doc [PR#214](https://github.com/silvioubaldino/personal-finance/pull/214)
 - Fixed user provisiong metric [PR#213](https://github.com/silvioubaldino/personal-finance/pull/213)
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,6 +2,16 @@
 
 This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
 
+Service repo (api) of the Personal Finance product. Shares product context (vision,
+requirements, cross-repo design, domain glossary) with the web and mobile repos through
+`personal-finance-context`.
+
+## This repo's role
+
+Owner of the API contracts. This repo implements what the AYD (cross-repo design) docs in the
+context repo define for the API; web and mobile consume those contracts. A contract change is
+a PR in `personal-finance-context` (AYD/ADR) — never redefined locally here.
+
 ## Commands
 
 ```bash
@@ -97,3 +107,30 @@ Always wrap errors upward using the domain wrap helpers; the API layer handles f
 ### Logging
 
 Custom Zap wrapper in `pkg/log/`. Use `log.InfoContext(ctx, msg, fields...)` / `log.ErrorContext(ctx, msg, fields...)` for structured, context-aware logging. `log.Err(err)` is the field helper for errors.
+
+## Engineering conventions (local)
+
+@docs/conventions/code-style.md
+@docs/conventions/testing.md
+@docs/conventions/git.md
+
+## Docs framework (summary)
+
+This repo follows the specs-driven docs framework shared across the product's repos. The
+framework's full rules live in `personal-finance-context` (`_meta/conventions.md`,
+`_meta/glossary.md`).
+
+- **Read-only context:** run `docs/scripts/sync-context.sh` to populate `docs/shared/` (a
+  **gitignored** mirror of the context repo — never edit it here). Once synced:
+  `docs/shared/manifest.md` (doc map) · `docs/shared/_meta/glossary.md` (ALWAYS use these
+  terms) · `docs/shared/_meta/conventions.md` (IDs, frontmatter, `ID@repo` refs).
+- **What lives in this repo:** `docs/specs/` (SPEC), `docs/plans/` (PLAN),
+  `docs/technical_decisions/` (local TDR), `docs/conventions/` (CONV), `docs/swagger.yaml`
+  (API contract, still pending migration into the framework). The changelog stays at the
+  existing root `CHANGELOG.md` (Keep a Changelog format, predates this framework and plays
+  the same role as the framework's `docs/changelog.md`).
+- **Contracts only change in the context repo** (AYD/ADR). If this API diverges from an AYD,
+  flag it — do not adapt silently (see `conventions.md` §5).
+- **Feature flow:** read the relevant AYD in `docs/shared/design/` → create/update the SPEC
+  here (`parents: [AYD-NNN@context]`) → write the PLAN and implement → contract changed? go
+  back to the AYD in `personal-finance-context` before proceeding.

--- a/docs/conventions/code-style.md
+++ b/docs/conventions/code-style.md
@@ -13,9 +13,22 @@
     `internal/domain/{feature}/{service,repository,api}`.
   - **Clean Architecture** (features novas: creditcard, invoice, transfer, subscription,
     agent...): `internal/usecase/`, `internal/infrastructure/{api,repository}/`,
-    `internal/bootstrap/{feature}/setup.go`.
-  - Features novas devem seguir o caminho clean architecture (skills `go-usecases`,
-    `go-api-handlers`, `go-bootstrap` detalham as convenções de cada camada).
+    `internal/bootstrap/{feature}/setup.go`. Features novas devem seguir este caminho.
+- **Convenções por camada (clean architecture):** regras completas e templates canônicos
+  vivem nas skills abaixo — fonte única da verdade, não duplicadas aqui; resumo do essencial:
+  - **Usecase** (`internal/usecase/{feature}_usecase.go`) — skill `go-usecases`: struct
+    nomeada pela entidade, sem sufixo `Usecase` (`Movement`, não `MovementUsecase`);
+    interfaces de dependência (`{Feature}Repository`/`Gateway`/`UseCase`) declaradas no
+    próprio arquivo, nunca importa o struct concreto; erro do dependente sobe com
+    `fmt.Errorf("...: %w", err)`, regra de negócio rejeitada sobe com `domain.WrapXxx`.
+  - **Handler** (`internal/infrastructure/api/{feature}_api.go`) — skill `go-api-handlers`:
+    mesma regra de interface estreita (`{Feature}Usecase`) declarada no próprio arquivo;
+    handler sem lógica de negócio (só parse → chama usecase → formata resposta); todo erro
+    passa por `HandleErr(c, ctx, err)`, nunca um JSON de erro feito à mão.
+  - **Bootstrap/DI** (`internal/bootstrap/{feature}/setup.go`) — skill `go-bootstrap`: um
+    `Setup(r, registry)` por feature, registrado em `SetupCleanArchComponents`; repositório
+    exposto via `Registry.Get{X}Repository()` (lazy nil-check); gateways externos (Stripe,
+    Firebase...) nunca ficam memoizados no registry.
 - **Tratamento de erros / logging:** três camadas de erro — repository → domain → HTTP (ver
   `CLAUDE.md` → Error Handling); sempre subir o erro com `domain.WrapXxx(err, contexto)`.
   Logging estruturado via `pkg/log` (`log.InfoContext`/`log.ErrorContext`, `log.Err(err)`).

--- a/docs/conventions/code-style.md
+++ b/docs/conventions/code-style.md
@@ -1,0 +1,21 @@
+# Estilo de código (deste repo)
+
+- **Linguagem / versão:** Go (ver `go.mod` para a versão mínima).
+- **Linter / formatter:** `make gofumpt` (gofumpt), `make imports` (goimports), `make linter`
+  (golangci-lint, config em `.code_quality/.golangci.yml`: gofmt, goimports, govet). `make all`
+  roda format + lint + test de uma vez.
+- **Nomenclatura:** use os termos do glossário (`docs/shared/_meta/glossary.md`) — sempre em
+  **inglês** (structs, campos, rotas, entidades canônicas: `Movement`, `Wallet`, `Invoice`...).
+  Documentação e comentários podem ser em português.
+- **Estrutura de pastas:** duas arquiteturas convivem durante a migração gradual (ver
+  `CLAUDE.md` → Architecture):
+  - **Legacy** (movement, wallet, category, balance, estimate):
+    `internal/domain/{feature}/{service,repository,api}`.
+  - **Clean Architecture** (features novas: creditcard, invoice, transfer, subscription,
+    agent...): `internal/usecase/`, `internal/infrastructure/{api,repository}/`,
+    `internal/bootstrap/{feature}/setup.go`.
+  - Features novas devem seguir o caminho clean architecture (skills `go-usecases`,
+    `go-api-handlers`, `go-bootstrap` detalham as convenções de cada camada).
+- **Tratamento de erros / logging:** três camadas de erro — repository → domain → HTTP (ver
+  `CLAUDE.md` → Error Handling); sempre subir o erro com `domain.WrapXxx(err, contexto)`.
+  Logging estruturado via `pkg/log` (`log.InfoContext`/`log.ErrorContext`, `log.Err(err)`).

--- a/docs/conventions/git.md
+++ b/docs/conventions/git.md
@@ -1,0 +1,14 @@
+# Convenções de Git (deste repo)
+
+- **Branches:** `feature/<slug>` (ex.: `feature/api-create-authorization`) ou
+  `bugfix/<slug>` (ex.: `bugfix/kubernetes`), a partir de `develop`. Ao trabalhar a partir de
+  uma SPEC/PLAN, inclua o ID no slug (ex.: `feature/SPEC-012-credit-card-limit`).
+- **Commits:** mensagem curta no imperativo (ex.: `Fix 500 on credit card movement when
+  default wallet is nil`); `feat(scope): ...` / `fix(scope): ...` (Conventional Commits) em
+  mudanças maiores. Referencie o ID (SPEC/PLAN) quando aplicável.
+- **PRs:** merge via squash contra `develop` (GitHub anexa `(#NNN)` à mensagem
+  automaticamente); cada PR soma uma linha ao `CHANGELOG.md` (raiz do repo, formato Keep a
+  Changelog). PR não altera contrato — isso é PR no repo de contexto
+  (`personal-finance-context`).
+- **Antes do PR:** `make all` (format + lint + test); se a SPEC depender do contexto
+  compartilhado, rode `docs/scripts/sync-context.sh` para validar contra o contexto atual.

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -1,0 +1,19 @@
+# Padrões de teste (deste repo)
+
+> Padrão de engenharia (vivo). Decisão pontual sobre testes que mude a abordagem → vira TDR.
+> Regras completas e template canônico: skill `go-unit-tests`
+> (`.claude/skills/go-unit-tests/SKILL.md`).
+
+- **Estrutura:** AAA (Arrange, Act, Assert), com comentário marcando cada seção.
+- **Localização:** `*_test.go` no mesmo diretório do código testado, `package <feature>_test`
+  (external test package).
+- **Formato:** um teste table-driven por função, tabela `map[string]struct{...}` (chave = nome
+  do caso, ex.: `"should return ErrNotFound when movement does not exist"`). Sem `if`/`switch`
+  no corpo do teste — toda variação entra pela tabela, não por controle de fluxo.
+- **Cobertura:** todo critério de aceite de uma SPEC tem um teste correspondente.
+- **Mocks:** `testify/mock`, só na fronteira (repository, gateway), nunca a unidade testada.
+  Reusar mock existente (`mock_test.go`) antes de criar um novo; nunca `mock.Anything`.
+- **Asserções:** `testify/assert`; comparar erros sempre com `assert.ErrorIs`, inclusive no
+  caminho de sucesso (nunca `assert.NoError`/`err == nil`).
+- **Comando:** `go test ./internal/path/to/package/...` (pacote) · `make test` (suite
+  completa, com `-race` e cobertura).

--- a/docs/conventions/testing.md
+++ b/docs/conventions/testing.md
@@ -1,19 +1,11 @@
 # Padrões de teste (deste repo)
 
 > Padrão de engenharia (vivo). Decisão pontual sobre testes que mude a abordagem → vira TDR.
-> Regras completas e template canônico: skill `go-unit-tests`
-> (`.claude/skills/go-unit-tests/SKILL.md`).
 
-- **Estrutura:** AAA (Arrange, Act, Assert), com comentário marcando cada seção.
-- **Localização:** `*_test.go` no mesmo diretório do código testado, `package <feature>_test`
-  (external test package).
-- **Formato:** um teste table-driven por função, tabela `map[string]struct{...}` (chave = nome
-  do caso, ex.: `"should return ErrNotFound when movement does not exist"`). Sem `if`/`switch`
-  no corpo do teste — toda variação entra pela tabela, não por controle de fluxo.
+As regras de teste (estrutura AAA, formato table-driven, convenção de mocks `testify/mock`,
+asserções `testify/assert`, template canônico) são definidas e mantidas **só** na skill
+`go-unit-tests` (`.claude/skills/go-unit-tests/SKILL.md`) — fonte única da verdade; não
+duplicadas aqui para não divergir dela. Ao tocar um teste, siga a skill.
+
+O que a skill não cobre (framework de docs):
 - **Cobertura:** todo critério de aceite de uma SPEC tem um teste correspondente.
-- **Mocks:** `testify/mock`, só na fronteira (repository, gateway), nunca a unidade testada.
-  Reusar mock existente (`mock_test.go`) antes de criar um novo; nunca `mock.Anything`.
-- **Asserções:** `testify/assert`; comparar erros sempre com `assert.ErrorIs`, inclusive no
-  caminho de sucesso (nunca `assert.NoError`/`err == nil`).
-- **Comando:** `go test ./internal/path/to/package/...` (pacote) · `make test` (suite
-  completa, com `-race` e cobertura).

--- a/docs/plans/PLAN-000-template.md
+++ b/docs/plans/PLAN-000-template.md
@@ -1,0 +1,35 @@
+---
+id: PLAN-NNN
+type: plan
+title: 
+status: draft
+created: 2025-01-01
+updated: 2025-01-01
+owner: <nome>
+parents: [SPEC-NNN]         # a spec que este plano implementa
+children: []
+related: []
+tags: []
+superseded_by: null
+---
+
+# Plano de Implementação: <feature>
+
+> Documento de trabalho (efêmero). Decisões técnicas não triviais viram TDR.
+
+## Abordagem técnica
+_Resumo da estratégia._
+
+## Passos de implementação
+1. 
+2. 
+
+## Arquivos / módulos afetados
+- 
+
+## Testes (ver docs/conventions/testing.md)
+- **Aceite (mapeia os critérios da SPEC):**
+- **Unit/integração:**
+
+## Checklist de tasks
+- [ ] 

--- a/docs/scripts/sync-context.sh
+++ b/docs/scripts/sync-context.sh
@@ -1,0 +1,14 @@
+#!/usr/bin/env sh
+# Sincroniza a camada compartilhada (repo de contexto) para docs/shared/.
+# Espelho read-only e gitignored. Rode ANTES de abrir o Claude Code
+# (os @imports do CLAUDE.md carregam no início da sessão).
+set -e
+cd "$(dirname "$0")/../.."
+
+CONTEXT_REPO="git@github.com:silvioubaldino/personal-finance-context.git"
+CONTEXT_REF="main"   # troque por uma tag/commit para fixar o contexto
+
+rm -rf docs/shared
+git clone --depth 1 --branch "$CONTEXT_REF" "$CONTEXT_REPO" docs/shared
+rm -rf docs/shared/.git   # vira cópia simples (não um repo aninhado)
+echo "✓ contexto sincronizado em docs/shared/ ($CONTEXT_REF)"

--- a/docs/specs/SPEC-000-template.md
+++ b/docs/specs/SPEC-000-template.md
@@ -1,0 +1,39 @@
+---
+id: SPEC-NNN
+type: spec
+title: 
+status: draft
+created: 2025-01-01
+updated: 2025-01-01
+owner: <nome>
+parents: [AYD-NNN@context]   # obrigatório: o AYD que originou esta spec
+children: []                # PLAN correspondente
+related: [GLO]              # ADR/TDR relevantes
+tags: []
+superseded_by: null
+---
+
+# Spec: <feature> (parte deste repo)
+
+> Detalha O QUÊ este repo faz para cumprir o AYD. Congela ao virar `approved`.
+
+## Objetivo
+_O papel deste repo nesta feature (conforme o AYD)._
+
+## Critérios de aceite
+```gherkin
+Cenário: <nome>
+  Dado <contexto>
+  Quando <ação>
+  Então <resultado observável>
+```
+
+## Contratos consumidos/expostos
+_Referencie os contratos do AYD. Este repo NÃO os redefine._
+
+## Modelo de dados / componentes afetados
+- 
+
+## Casos de borda & fora de escopo
+- Borda:
+- Fora:

--- a/docs/technical_decisions/TDR-000-template.md
+++ b/docs/technical_decisions/TDR-000-template.md
@@ -1,0 +1,28 @@
+---
+id: TDR-NNN
+type: tdr
+title: 
+status: draft               # proposed → accepted → superseded
+created: 2025-01-01
+updated: 2025-01-01
+owner: <nome>
+parents: []
+related: []
+tags: []
+superseded_by: null
+---
+
+# TDR-NNN: <decisão técnica local>
+
+> Append-only: nunca reescreva. Decisão nova = novo TDR que substitui este.
+> Use TDR para decisões internas DESTE repo. Se a decisão afeta outro repo
+> (contrato/protocolo), ela é um ADR no repo de contexto, não um TDR.
+
+## Contexto
+_Que força técnica local exige a decisão?_
+
+## Decisão
+_O que foi decidido._
+
+## Alternativas & trade-offs
+- 


### PR DESCRIPTION
## Summary
- Adds the service-repo structure from the docs framework (`personal-finance-context`): `docs/specs/`, `docs/plans/`, `docs/technical_decisions/`, `docs/conventions/` (filled in with this repo's real testing/code-style/git practices), and `docs/scripts/sync-context.sh` (pointed at `personal-finance-context`).
- Extends `CLAUDE.md` with the framework-defined sections — **"This repo's role"** and **"Docs framework (summary)"** — plus an **"Engineering conventions (local)"** section that `@imports` the new `docs/conventions/*.md` files. Nothing existing was removed.
- Leaves `docs/swagger.yaml` untouched (per the framework, migrating it into a SPEC is a follow-up) and keeps the existing root `CHANGELOG.md` as the changelog (documented as the equivalent of the framework's `docs/changelog.md`, since this repo already had one in Keep a Changelog format).

## Test plan
- [ ] Confirm `docs/scripts/sync-context.sh` successfully clones `personal-finance-context` into `docs/shared/` and is correctly gitignored.
- [ ] Review that the new `CLAUDE.md` sections don't conflict with existing guidance.
- [ ] Decide/track the follow-up to migrate `docs/swagger.yaml` into the framework.

https://claude.ai/code/session_01VTmc3HwoJg3WH3sWckXjAS


---
_Generated by [Claude Code](https://claude.ai/code/session_01VTmc3HwoJg3WH3sWckXjAS)_