### PR TITLE
Fix CORS blocking all requests (X-Request-ID header)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+-
+
+## Relase - v1.21.0 - 31/07/2026
+
 - Fixed CORS blocking all requests: allowed the `X-Request-ID` header sent by the web/mobile clients [PR#218](https://github.com/silvioubaldino/personal-finance/pull/218)
 - Updated golang.org/x/image lib due to high-severity vulnerability
 - Added docs framework structure [PR#215](https://github.com/silvioubaldino/personal-finance/pull/215)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
-- Fixed CORS blocking all requests: allowed the `X-Request-ID` header sent by the web/mobile clients
+- Fixed CORS blocking all requests: allowed the `X-Request-ID` header sent by the web/mobile clients [PR#218](https://github.com/silvioubaldino/personal-finance/pull/218)
 - Updated golang.org/x/image lib due to high-severity vulnerability
 - Added docs framework structure [PR#215](https://github.com/silvioubaldino/personal-finance/pull/215)
 - Removed unused doc [PR#214](https://github.com/silvioubaldino/personal-finance/pull/214)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Unreleased
 
+- Fixed CORS blocking all requests: allowed the `X-Request-ID` header sent by the web/mobile clients
 - Updated golang.org/x/image lib due to high-severity vulnerability
 - Added docs framework structure [PR#215](https://github.com/silvioubaldino/personal-finance/pull/215)
 - Removed unused doc [PR#214](https://github.com/silvioubaldino/personal-finance/pull/214)

--- a/cmd/api/main.go
+++ b/cmd/api/main.go
@@ -90,7 +90,12 @@ func setupGin(logger log.Logger, db *gorm.DB) (*gin.Engine, authentication.Authe
 
 	corsConfig := cors.DefaultConfig()
 	corsConfig.AllowAllOrigins = true // TODO
-	corsConfig.AllowHeaders = []string{authentication.UserToken, authentication.APIKeyHeader, "Content-Type"}
+	corsConfig.AllowHeaders = []string{
+		authentication.UserToken,
+		authentication.APIKeyHeader,
+		"Content-Type",
+		"X-Request-ID",
+	}
 	r.Use(cors.New(corsConfig))
 
 	// Liveness/readiness probes are unauthenticated, registered before auth.


### PR DESCRIPTION
## Summary
- Prod outage: the web/mobile fetcher added an `X-Request-ID` header (telemetry correlation) that isn't CORS-safelisted, turning every request into a preflight; the backend allowlist never included that header, so every preflight failed and the app was down.
- Adds `X-Request-ID` to `corsConfig.AllowHeaders` in `cmd/api/main.go`.

## Test plan
- [x] `go build ./cmd/api/`
- [ ] Confirm preflight response now includes `X-Request-ID` in `Access-Control-Allow-Headers` against a deployed environment

Root cause and immediate mitigation (Vercel rollback) were investigated by the user; this PR is the backend fix only.