### PR TITLE
Fix Cloud Build failure: bump builder image to golang:1.25-alpine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 -
 
+## Relase - v1.21.1 - 31/07/2026
+
+- Fixed Cloud Build failure: bumped builder image to `golang:1.25-alpine` to match `go.mod` requirement introduced by the x/image upgrade
+
 ## Relase - v1.21.0 - 31/07/2026
 
 - Fixed CORS blocking all requests: allowed the `X-Request-ID` header sent by the web/mobile clients [PR#218](https://github.com/silvioubaldino/personal-finance/pull/218)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## Relase - v1.21.1 - 31/07/2026
 
-- Fixed Cloud Build failure: bumped builder image to `golang:1.25-alpine` to match `go.mod` requirement introduced by the x/image upgrade
+- Fixed Cloud Build failure: bumped builder image to `golang:1.25-alpine` to match `go.mod` requirement introduced by the x/image upgrade [PR#220](https://github.com/silvioubaldino/personal-finance/pull/220)
 
 ## Relase - v1.21.0 - 31/07/2026
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build stage
-FROM golang:1.24-alpine AS builder
+FROM golang:1.25-alpine AS builder
 
 # Instala certificados CA necessários para HTTPS
 RUN apk add --no-cache ca-certificates git


### PR DESCRIPTION
## Summary
- Cloud Build was failing on `go mod download` with `go: go.mod requires go >= 1.25.0 (running go 1.24.13; GOTOOLCHAIN=local)`
- Root cause: PR #217 (x/image vulnerability fix) bumped the `go` directive in `go.mod` to `1.25.0`, but the Dockerfile builder stage was still pinned to `golang:1.24-alpine`
- Bumped builder stage to `golang:1.25-alpine` to match

## Test plan
- [x] `docker build --platform linux/amd64 -t personal-finance:local-test .` completes successfully (all 16 steps, exit 0)
- [x] Verified binary and migrations present in the built image